### PR TITLE
Add support for com.android.feature

### DIFF
--- a/android-junit5/src/main/groovy/de/mannodermaus/gradle/plugins/android_junit5/AndroidJUnitPlatformPlugin.groovy
+++ b/android-junit5/src/main/groovy/de/mannodermaus/gradle/plugins/android_junit5/AndroidJUnitPlatformPlugin.groovy
@@ -1,13 +1,11 @@
 package de.mannodermaus.gradle.plugins.android_junit5
 
-import com.android.build.gradle.api.BaseVariant
 import de.mannodermaus.gradle.plugins.android_junit5.jacoco.AndroidJUnit5JacocoExtension
 import de.mannodermaus.gradle.plugins.android_junit5.jacoco.AndroidJUnit5JacocoReport
 import de.mannodermaus.gradle.plugins.android_junit5.kotlin.AndroidJUnit5CopyKotlin
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.ProjectConfigurationException
 import org.gradle.util.GradleVersion
 import org.junit.platform.gradle.plugin.*
 
@@ -49,13 +47,8 @@ class AndroidJUnitPlatformPlugin implements Plugin<Project> {
           "android-junit5 plugin requires Gradle version $MIN_REQUIRED_GRADLE_VERSION or higher")
     }
 
+    // Validates that the project's plugins are configured correctly
     this.projectConfig = new ProjectConfig(project)
-
-    // Validate that an Android plugin is applied
-    if (!projectConfig.androidPluginApplied) {
-      throw new ProjectConfigurationException(
-          "The android or android-library plugin must be applied to this project", null)
-    }
 
     configureExtensions(project)
     configureDependencies(project)
@@ -194,15 +187,12 @@ class AndroidJUnitPlatformPlugin implements Plugin<Project> {
   private def configureTasks(Project project) {
     // Add the test task to each of the project's unit test variants,
     // and connect a Code Coverage report to it if Jacoco is enabled.
-    def allVariants = projectConfig.androidLibraryPluginApplied ? "libraryVariants" :
-        "applicationVariants"
-    def testVariants = project.android[allVariants].findAll { it.hasProperty("unitTestVariant") }
-
+    def testVariants = projectConfig.unitTestVariants
     def isJacocoApplied = projectConfig.jacocoPluginApplied
     def isKotlinApplied = projectConfig.kotlinPluginApplied
 
     testVariants.each { variant ->
-      def testTask = AndroidJUnit5Test.create(projectConfig, variant as BaseVariant)
+      def testTask = AndroidJUnit5Test.create(projectConfig, variant)
 
       if (isJacocoApplied) {
         AndroidJUnit5JacocoReport.create(project, testTask)

--- a/android-junit5/src/main/groovy/de/mannodermaus/gradle/plugins/android_junit5/ProjectConfig.groovy
+++ b/android-junit5/src/main/groovy/de/mannodermaus/gradle/plugins/android_junit5/ProjectConfig.groovy
@@ -1,25 +1,50 @@
 package de.mannodermaus.gradle.plugins.android_junit5
 
-import com.android.build.gradle.AppPlugin
-import com.android.build.gradle.LibraryPlugin
-import com.android.build.gradle.TestPlugin
+import com.android.build.gradle.api.BaseVariant
 import org.gradle.api.Project
+import org.gradle.api.ProjectConfigurationException
 
 class ProjectConfig {
 
+  private enum Type {
+    APPLICATION("com.android.application", "applicationVariants"),
+    TEST("com.android.test", "applicationVariants"),
+    LIBRARY("com.android.library", "libraryVariants"),
+
+    // Although there are "featureVariants" for modules with the FeaturePlugin,
+        // there is no distinct per-feature test task.
+        // Therefore, we use the default library variants
+        FEATURE("com.android.feature", "libraryVariants")
+
+    private final String pluginId
+    private final String variantListName
+
+    Type(String pluginId, String variantListName) {
+      this.pluginId = pluginId
+      this.variantListName = variantListName
+    }
+
+    static Type ofProject(Project project) throws ProjectConfigurationException {
+      def type = values().find { project.plugins.findPlugin(it.pluginId) }
+      if (type == null) {
+        throw new ProjectConfigurationException("An Android plugin must be applied to this project",
+            null)
+      }
+      return type
+    }
+  }
+
   final Project project
+  final Type type
 
   ProjectConfig(Project project) {
+    this.type = Type.ofProject(project)
     this.project = project
   }
 
-  boolean isAndroidPluginApplied() {
-    return project.plugins.findPlugin(AppPlugin.class) || project.plugins.findPlugin(
-        TestPlugin.class) || isAndroidLibraryPluginApplied()
-  }
-
-  boolean isAndroidLibraryPluginApplied() {
-    return project.plugins.findPlugin(LibraryPlugin.class)
+  List<? super BaseVariant> getUnitTestVariants() {
+    def allVariants = project.android[type.variantListName] as List<? super BaseVariant>
+    return allVariants.findAll { it.hasProperty("unitTestVariant") }
   }
 
   boolean isJacocoPluginApplied() {

--- a/android-junit5/src/main/groovy/de/mannodermaus/gradle/plugins/android_junit5/ProjectConfig.groovy
+++ b/android-junit5/src/main/groovy/de/mannodermaus/gradle/plugins/android_junit5/ProjectConfig.groovy
@@ -11,9 +11,9 @@ class ProjectConfig {
     TEST("com.android.test", "applicationVariants"),
     LIBRARY("com.android.library", "libraryVariants"),
 
-    // Although there are "featureVariants" for modules with the FeaturePlugin,
-        // there is no distinct per-feature test task.
-        // Therefore, we use the default library variants
+    // Although there are "featureVariants" for modules applying the Feature plugin,
+        // there is no distinct per-feature test task per se.
+        // Therefore, we use the default library variants here
         FEATURE("com.android.feature", "libraryVariants")
 
     private final String pluginId

--- a/android-junit5/src/test/groovy/de/mannodermaus/gradle/plugins/android_junit5/BasePluginSpec.groovy
+++ b/android-junit5/src/test/groovy/de/mannodermaus/gradle/plugins/android_junit5/BasePluginSpec.groovy
@@ -59,7 +59,7 @@ abstract class BasePluginSpec extends Specification {
 
     then:
     def expect = thrown(PluginApplicationException)
-    expect.cause.message == "The android or android-library plugin must be applied to this project"
+    expect.cause.message == "An Android plugin must be applied to this project"
   }
 
   def "Requires Gradle 2.5 or later"() {

--- a/android-junit5/src/test/groovy/de/mannodermaus/gradle/plugins/android_junit5/util/TestProjectFactory.groovy
+++ b/android-junit5/src/test/groovy/de/mannodermaus/gradle/plugins/android_junit5/util/TestProjectFactory.groovy
@@ -28,7 +28,7 @@ class TestProjectFactory {
   class TestProjectBuilder {
 
     enum Type {
-      UNSET, APPLICATION, LIBRARY
+      UNSET, APPLICATION, LIBRARY, FEATURE
     }
 
     private final Project project
@@ -57,6 +57,15 @@ class TestProjectFactory {
       }
 
       projectType = Type.APPLICATION
+      return this
+    }
+
+    TestProjectBuilder asAndroidFeature() {
+      if (projectType != Type.UNSET) {
+        throw new IllegalArgumentException("Project type already set to $projectType")
+      }
+
+      projectType = Type.FEATURE
       return this
     }
 
@@ -98,6 +107,10 @@ class TestProjectFactory {
       switch (projectType) {
         case Type.APPLICATION:
           project.apply plugin: "com.android.application"
+          break
+
+        case Type.FEATURE:
+          project.apply plugin: "com.android.feature"
           break
 
         case Type.LIBRARY:

--- a/android-junit5/src/testAgp3x/groovy/de/mannodermaus/gradle/plugins/android_junit5/AGP3PluginSpec.groovy
+++ b/android-junit5/src/testAgp3x/groovy/de/mannodermaus/gradle/plugins/android_junit5/AGP3PluginSpec.groovy
@@ -75,4 +75,31 @@ class AGP3PluginSpec extends BasePluginSpec {
     assert runAll.getDependsOn()
         .containsAll([runDebugFree, runDebugPaid, runReleaseFree, runReleasePaid])
   }
+
+  def "Feature: Basic Integration"() {
+    when:
+    Project project = factory.newProject(rootProject())
+        .asAndroidFeature()
+        .applyJunit5Plugin()
+        .build()
+
+    project.android {
+      buildTypes {
+        staging {}
+      }
+    }
+
+    project.evaluate()
+
+    then:
+    // These statements automatically assert the existence of the tasks,
+    // and raise an Exception if absent
+    def runDebug = project.tasks.getByName("junitPlatformTestDebug")
+    def runRelease = project.tasks.getByName("junitPlatformTestRelease")
+    def runStaging = project.tasks.getByName("junitPlatformTestStaging")
+    def runAll = project.tasks.getByName("junitPlatformTest")
+
+    // Assert that dependency chain is valid
+    assert runAll.getDependsOn().containsAll([runDebug, runRelease, runStaging])
+  }
 }

--- a/android-junit5/src/testAgp3x/groovy/de/mannodermaus/gradle/plugins/android_junit5/AGP3PluginSpec.groovy
+++ b/android-junit5/src/testAgp3x/groovy/de/mannodermaus/gradle/plugins/android_junit5/AGP3PluginSpec.groovy
@@ -102,4 +102,63 @@ class AGP3PluginSpec extends BasePluginSpec {
     // Assert that dependency chain is valid
     assert runAll.getDependsOn().containsAll([runDebug, runRelease, runStaging])
   }
+
+  def "Feature: Jacoco Integration"() {
+    when:
+    Project project = factory.newProject(rootProject())
+        .asAndroidFeature()
+        .applyJunit5Plugin()
+        .applyJacocoPlugin()
+        .buildAndEvaluate()
+
+    then:
+    // These statements automatically assert the existence of the tasks,
+    // and raise an Exception if absent
+    def runDebug = project.tasks.getByName("jacocoTestReportDebug")
+    def runRelease = project.tasks.getByName("jacocoTestReportRelease")
+    def runAll = project.tasks.getByName("jacocoTestReport")
+
+    // Assert that dependency chain is valid
+    assert runAll.getDependsOn().containsAll([runDebug, runRelease])
+  }
+
+  def "Feature: Jacoco Tasks not added if plugin absent"() {
+    when:
+    def project = factory.newProject(rootProject())
+        .asAndroidFeature()
+        .applyJunit5Plugin()
+        .applyJacocoPlugin(false)
+        .buildAndEvaluate()
+
+    then:
+    project.tasks.findByName("jacocoTestReport") == null
+    project.tasks.findByName("jacocoTestReportDebug") == null
+    project.tasks.findByName("jacocoTestReportRelease") == null
+  }
+
+  def "Feature: Kotlin Integration"() {
+    when:
+    def project = factory.newProject(rootProject())
+        .asAndroidFeature()
+        .applyJunit5Plugin()
+        .applyKotlinPlugin()
+        .buildAndEvaluate()
+
+    then:
+    project.tasks.getByName("copyKotlinUnitTestClassesDebug")
+    project.tasks.getByName("copyKotlinUnitTestClassesRelease")
+  }
+
+  def "Feature: Kotlin Tasks not added if plugin absent"() {
+    when:
+    def project = factory.newProject(rootProject())
+        .asAndroidFeature()
+        .applyJunit5Plugin()
+        .applyKotlinPlugin(false)
+        .buildAndEvaluate()
+
+    then:
+    project.tasks.findByName("copyKotlinUnitTestClassesDebug") == null
+    project.tasks.findByName("copyKotlinUnitTestClassesRelease") == null
+  }
 }


### PR DESCRIPTION
AGP3 brought the `com.android.feature` plugin, which is pretty much just the Library plugin with a few additional DSLs. Still, because the JUnit 5 plugin detects Android modules directly, it needs to know about the `FeaturePlugin`. Also, that plugin brings in an alternative to `applicationVariants` & `libraryVariants` in the form of `featureVariants`, but it doesn't seem like the Android Gradle Plugin creates different test tasks for each feature. Therefore, we should be good with just using `libraryVariants` for the feature plugin.