### PR TITLE
Parity with JUnit 5.1.0-M1

### DIFF
--- a/.idea/runConfigurations/Sample__Run_Unit_Tests__Gradle_.xml
+++ b/.idea/runConfigurations/Sample__Run_Unit_Tests__Gradle_.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Sample: Run Unit Tests (Gradle)" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":sample:junitPlatformTest" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <method />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Sample__Run_Unit_Tests__IDE_.xml
+++ b/.idea/runConfigurations/Sample__Run_Unit_Tests__IDE_.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Sample: Run Unit Tests" type="AndroidJUnit" factoryName="Android JUnit">
+  <configuration default="false" name="Sample: Run Unit Tests (IDE)" type="AndroidJUnit" factoryName="Android JUnit">
     <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
     <module name="sample" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />

--- a/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Constants.kt
+++ b/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Constants.kt
@@ -1,7 +1,5 @@
 package de.mannodermaus.gradle.plugins.junit5
 
-const val LOG_TAG = "[android-junit5]"
-
 const val MIN_REQUIRED_GRADLE_VERSION = "2.5"
 const val VERSIONS_RESOURCE_NAME = "versions.properties"
 

--- a/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Functions.kt
+++ b/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Functions.kt
@@ -11,6 +11,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.logging.Logger
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.tasks.TaskContainer
@@ -107,8 +108,8 @@ private fun <T> Any.extensionByName(name: String): T {
 /**
  * Log the provided info message using the plugin's Log Tag.
  */
-fun Project.logInfo(text: String) {
-  logger.info("$LOG_TAG: $text")
+fun Logger.junit5Info(text: String) {
+  info("[android-junit5]: $text")
 }
 
 /**

--- a/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Plugin.kt
+++ b/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Plugin.kt
@@ -1,8 +1,8 @@
 package de.mannodermaus.gradle.plugins.junit5
 
 import com.android.build.gradle.api.BaseVariant
-import de.mannodermaus.gradle.plugins.junit5.providers.JavaDirectoryProvider
 import de.mannodermaus.gradle.plugins.junit5.providers.DirectoryProvider
+import de.mannodermaus.gradle.plugins.junit5.providers.JavaDirectoryProvider
 import de.mannodermaus.gradle.plugins.junit5.providers.KotlinDirectoryProvider
 import de.mannodermaus.gradle.plugins.junit5.tasks.AndroidJUnit5JacocoReport
 import de.mannodermaus.gradle.plugins.junit5.tasks.AndroidJUnit5UnitTest
@@ -98,7 +98,7 @@ class AndroidJUnitPlatformPlugin : Plugin<Project> {
     val testVariants = projectConfig.unitTestVariants
     val isJacocoApplied = projectConfig.jacocoPluginApplied
 
-    testVariants.forEach { variant ->
+    testVariants.all { variant ->
       val directoryProviders = collectDirectoryProviders(variant)
 
       // Create JUnit 5 test task
@@ -111,10 +111,11 @@ class AndroidJUnitPlatformPlugin : Plugin<Project> {
     }
   }
 
-  private fun Project.collectDirectoryProviders(variant: BaseVariant): Collection<DirectoryProvider> {
+  private fun Project.collectDirectoryProviders(
+      variant: BaseVariant): Collection<DirectoryProvider> {
     val providers = mutableSetOf<DirectoryProvider>()
 
-    // Default JUnit 5 directories
+    // Default Java directories
     providers += JavaDirectoryProvider(variant)
 
     // Kotlin Integration

--- a/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/ProjectConfig.kt
+++ b/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/ProjectConfig.kt
@@ -5,11 +5,14 @@ import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.FeatureExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.TestExtension
+import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.api.BaseVariant
+import com.android.build.gradle.api.LibraryVariant
 import de.mannodermaus.gradle.plugins.junit5.Type.Application
 import de.mannodermaus.gradle.plugins.junit5.Type.Feature
 import de.mannodermaus.gradle.plugins.junit5.Type.Library
 import de.mannodermaus.gradle.plugins.junit5.Type.Test
+import org.gradle.api.DomainObjectSet
 import org.gradle.api.Project
 import org.gradle.api.ProjectConfigurationException
 
@@ -32,20 +35,20 @@ class ProjectConfig(private val project: Project) {
 }
 
 private sealed class Type<in T : BaseExtension>(val pluginId: String) {
-  abstract fun variants(extension: T): Set<BaseVariant>
+  abstract fun variants(extension: T): DomainObjectSet<out BaseVariant>
 
   object Application : Type<AppExtension>("com.android.application") {
-    override fun variants(extension: AppExtension): Set<BaseVariant> =
+    override fun variants(extension: AppExtension): DomainObjectSet<ApplicationVariant> =
         extension.applicationVariants
   }
 
   object Test : Type<TestExtension>("com.android.test") {
-    override fun variants(extension: TestExtension): Set<BaseVariant> =
+    override fun variants(extension: TestExtension): DomainObjectSet<ApplicationVariant> =
         extension.applicationVariants
   }
 
   object Library : Type<LibraryExtension>("com.android.library") {
-    override fun variants(extension: LibraryExtension): Set<BaseVariant> =
+    override fun variants(extension: LibraryExtension): DomainObjectSet<LibraryVariant> =
         extension.libraryVariants
   }
 
@@ -53,7 +56,7 @@ private sealed class Type<in T : BaseExtension>(val pluginId: String) {
   // there is no distinct per-feature test task per se.
   // Therefore, we use the default library variants here
   object Feature : Type<FeatureExtension>("com.android.feature") {
-    override fun variants(extension: FeatureExtension): Set<BaseVariant> =
+    override fun variants(extension: FeatureExtension): DomainObjectSet<LibraryVariant> =
         extension.libraryVariants
   }
 }

--- a/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/providers/Java.kt
+++ b/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/providers/Java.kt
@@ -11,25 +11,18 @@ import de.mannodermaus.gradle.plugins.junit5.variantData
  */
 class JavaDirectoryProvider(private val variant: BaseVariant) : DirectoryProvider {
 
-  override fun mainSourceDirectories() =
-      javaSourceFoldersOf(variant)
-
-  override fun mainClassDirectories() =
-      javaClassFoldersOf(variant)
-
-  override fun testSourceDirectories() =
-      javaSourceFoldersOf(variant.unitTestVariant)
-
-  override fun testClassDirectories() =
-      javaClassFoldersOf(variant.unitTestVariant)
+  override fun mainSourceDirectories() = sourceFoldersOf(variant)
+  override fun testSourceDirectories() = sourceFoldersOf(variant.unitTestVariant)
+  override fun mainClassDirectories() = classFoldersOf(variant)
+  override fun testClassDirectories() = classFoldersOf(variant.unitTestVariant)
 
   /* Private */
 
-  private fun javaSourceFoldersOf(variant: BaseVariant) =
+  private fun sourceFoldersOf(variant: BaseVariant) =
       variant.sourceSets
           .flatMap { it.javaDirectories }
           .toSet()
 
-  private fun javaClassFoldersOf(variant: BaseVariant) =
+  private fun classFoldersOf(variant: BaseVariant) =
       setOf(variant.variantData.scope.javaOutputDir)
 }

--- a/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/providers/Kotlin.kt
+++ b/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/providers/Kotlin.kt
@@ -25,26 +25,19 @@ class KotlinDirectoryProvider(
     private val project: Project,
     private val variant: BaseVariant) : DirectoryProvider {
 
-  override fun mainSourceDirectories() =
-      kotlinSourceFoldersOf(variant)
-
-  override fun mainClassDirectories() =
-      kotlinClassFoldersOf(variant)
-
-  override fun testSourceDirectories() =
-      kotlinSourceFoldersOf(variant.unitTestVariant)
-
-  override fun testClassDirectories() =
-      kotlinClassFoldersOf(variant.unitTestVariant)
+  override fun mainSourceDirectories() = sourceFoldersOf(variant)
+  override fun testSourceDirectories() = sourceFoldersOf(variant.unitTestVariant)
+  override fun mainClassDirectories() = classFoldersOf(variant)
+  override fun testClassDirectories() = classFoldersOf(variant.unitTestVariant)
 
   /* Private */
 
-  private fun kotlinSourceFoldersOf(variant: BaseVariant) =
+  private fun sourceFoldersOf(variant: BaseVariant) =
       variant.sourceSets
           .flatMap { it.kotlin.srcDirs }
           .toSet()
 
-  private fun kotlinClassFoldersOf(variant: BaseVariant): Set<File> {
+  private fun classFoldersOf(variant: BaseVariant): Set<File> {
     val kotlinTask = project.tasks.findByName(variant.kotlinTaskName) ?: return emptySet()
     return setOf((kotlinTask as KotlinCompile).destinationDir)
   }

--- a/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/Jacoco.kt
+++ b/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/Jacoco.kt
@@ -1,7 +1,7 @@
 package de.mannodermaus.gradle.plugins.junit5.tasks
 
 import de.mannodermaus.gradle.plugins.junit5.jacoco
-import de.mannodermaus.gradle.plugins.junit5.logInfo
+import de.mannodermaus.gradle.plugins.junit5.junit5Info
 import de.mannodermaus.gradle.plugins.junit5.maybeCreate
 import de.mannodermaus.gradle.plugins.junit5.providers.DirectoryProvider
 import de.mannodermaus.gradle.plugins.junit5.providers.mainClassDirectories
@@ -75,10 +75,11 @@ open class AndroidJUnit5JacocoReport : JacocoReport() {
         xml.isEnabled = junit5Jacoco.xmlReport
       }
 
-      project.logInfo("Assembled Jacoco Code Coverage for JUnit 5 Task '${testTask.name}':")
-      project.logInfo("|__ Execution Data: ${reportTask.executionData.asPath}")
-      project.logInfo("|__ Source Dirs: ${reportTask.sourceDirectories.asPath}")
-      project.logInfo("|__ Class Dirs: ${reportTask.classDirectories.asPath}")
+      project.logger.junit5Info(
+          "Assembled Jacoco Code Coverage for JUnit 5 Task '${testTask.name}':")
+      project.logger.junit5Info("|__ Execution Data: ${reportTask.executionData.asPath}")
+      project.logger.junit5Info("|__ Source Dirs: ${reportTask.sourceDirectories.asPath}")
+      project.logger.junit5Info("|__ Class Dirs: ${reportTask.classDirectories.asPath}")
 
       // Hook into the main Jacoco task
       val defaultJacocoTask = project.tasks.maybeCreate(

--- a/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/UnitTest.kt
+++ b/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/UnitTest.kt
@@ -89,26 +89,41 @@ open class AndroidJUnit5UnitTest : JavaExec() {
       configureTaskDependencies(task, junit5)
       val reportsDir = configureTaskOutputs(task, junit5)
 
-      // Share the classpath with the default unit tests managed by Android,
-      // but append the JUnit Platform configuration at the end
+      // Aggregate test root directories from the given providers
+      val testRootDirs = directoryProviders.classDirectories()
+      project.logInfo("Assembled JUnit 5 Task '${task.name}':")
+      testRootDirs.forEach { project.logInfo("|__ $it") }
+
+      // Share the task's classpath with the default unit tests managed by Android,
+      // but append the JUnit Platform configuration at the end.
       //
       // Note: the user's test runtime classpath must come first; otherwise, code
       // instrumented by Clover in JUnit's build will be shadowed by JARs pulled in
       // via the junitPlatform configuration... leading to zero code coverage for
       // the respective modules.
-      task.classpath = getDefaultUnitTestTask().classpath +
+      val taskClasspath = getDefaultUnitTestTask().classpath +
           project.configurations.getByName("junitPlatform")
 
-      // Aggregate test root directories from the given providers
-      val testRootDirs = directoryProviders.classDirectories()
+      if (junit5.enableModulePath) {
+        // Set module-path and clear classpath and main class
+        task.jvmArgs = listOf(
+            "--module-path",
+            taskClasspath.asPath,
+            "--add-modules",
+            "ALL-MODULE-PATH"
+        )
 
-      project.logInfo("Assembled JUnit 5 Task '${task.name}':")
-      testRootDirs.forEach { project.logInfo("|__ $it") }
+        task.classpath = project.files()
+        task.main = ""
 
-      // Configure main class & arguments
-      task.main = ConsoleLauncher::class.java.name
+      } else {
+        // Use classpath property & configure ConsoleLauncher as the main class
+        task.classpath = taskClasspath
+        task.main = ConsoleLauncher::class.java.name
+      }
+
+      // Build the task arguments
       task.args = buildArgs(junit5, reportsDir, testRootDirs)
-
       project.logInfo("* JUnit 5 Arguments: ${task.args.joinToString()}")
 
       // Hook into the main JUnit 5 task
@@ -130,6 +145,7 @@ open class AndroidJUnit5UnitTest : JavaExec() {
       task.inputs.property("selectors.classes", junit5.selectors.classes)
       task.inputs.property("selectors.methods", junit5.selectors.methods)
       task.inputs.property("selectors.resources", junit5.selectors.resources)
+      task.inputs.property("selectors.modules", junit5.selectors.modules)
       task.inputs.property("filters.engines.include", junit5.filters.engines.include)
       task.inputs.property("filters.engines.exclude", junit5.filters.engines.exclude)
       task.inputs.property("filters.tags.include", junit5.filters.tags.include)
@@ -188,14 +204,25 @@ open class AndroidJUnit5UnitTest : JavaExec() {
         testRootDirs: List<File>): List<String> {
       val args = mutableListOf<String>()
 
+      // Java 9 Module Path
+      if (junit5.enableModulePath) {
+        args += arrayOf("--module", "org.junit.platform.console")
+      }
+
       // Log Details
       junit5.details?.let { args += arrayOf("--details", it.name) }
 
       // Selectors
       if (junit5.selectors.isEmpty()) {
-        // Employ classpath scanning if no selectors are given
-        args += arrayOf("--scan-class-path",
-            testRootDirs.joinToString(separator = File.pathSeparator))
+        args += if (junit5.enableModulePath) {
+          // Employ module path scanning if that is enabled
+          arrayOf("--scan-modules")
+
+        } else {
+          // Employ classpath scanning if no selectors are given
+          arrayOf("--scan-class-path",
+              testRootDirs.joinToString(separator = File.pathSeparator))
+        }
 
       } else {
         // Otherwise, add each selector individually
@@ -206,6 +233,7 @@ open class AndroidJUnit5UnitTest : JavaExec() {
         junit5.selectors.classes.forEach { args += arrayOf("-c", it) }
         junit5.selectors.methods.forEach { args += arrayOf("-m", it) }
         junit5.selectors.resources.forEach { args += arrayOf("-r", it) }
+        junit5.selectors.modules.forEach { args += arrayOf("-o", it) }
       }
 
       // Filters

--- a/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/UnitTest.kt
+++ b/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/UnitTest.kt
@@ -12,7 +12,7 @@ import de.mannodermaus.gradle.plugins.junit5.getExcludeClassNamePatterns
 import de.mannodermaus.gradle.plugins.junit5.getIncludeClassNamePatterns
 import de.mannodermaus.gradle.plugins.junit5.isEmpty
 import de.mannodermaus.gradle.plugins.junit5.junit5
-import de.mannodermaus.gradle.plugins.junit5.logInfo
+import de.mannodermaus.gradle.plugins.junit5.junit5Info
 import de.mannodermaus.gradle.plugins.junit5.packages
 import de.mannodermaus.gradle.plugins.junit5.providers.DirectoryProvider
 import de.mannodermaus.gradle.plugins.junit5.providers.classDirectories
@@ -91,8 +91,8 @@ open class AndroidJUnit5UnitTest : JavaExec() {
 
       // Aggregate test root directories from the given providers
       val testRootDirs = directoryProviders.classDirectories()
-      project.logInfo("Assembled JUnit 5 Task '${task.name}':")
-      testRootDirs.forEach { project.logInfo("|__ $it") }
+      project.logger.junit5Info("Assembled JUnit 5 Task '${task.name}':")
+      testRootDirs.forEach { project.logger.junit5Info("|__ $it") }
 
       // Share the task's classpath with the default unit tests managed by Android,
       // but append the JUnit Platform configuration at the end.
@@ -124,7 +124,7 @@ open class AndroidJUnit5UnitTest : JavaExec() {
 
       // Build the task arguments
       task.args = buildArgs(junit5, reportsDir, testRootDirs)
-      project.logInfo("* JUnit 5 Arguments: ${task.args.joinToString()}")
+      project.logger.junit5Info("* JUnit 5 Arguments: ${task.args.joinToString()}")
 
       // Hook into the main JUnit 5 task
       val defaultJUnit5Task = project.tasks.maybeCreate(TASK_NAME_DEFAULT)

--- a/buildSrc/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/WriteClasspathResource.kt
+++ b/buildSrc/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/WriteClasspathResource.kt
@@ -15,27 +15,20 @@ import java.io.File
  * More info:
  * https://docs.gradle.org/current/userguide/test_kit.html#sub:test-kit-classpath-injection
  */
-@Suppress("MemberVisibilityCanPrivate", "unused")
+@Suppress("unused")
 open class WriteClasspathResource : DefaultTask() {
 
   @InputFiles
-  var inputFiles: FileCollection? = null
+  lateinit var inputFiles: FileCollection
   @OutputDirectory
-  var outputDir: File? = null
-  var resourceFileName: String? = null
+  lateinit var outputDir: File
+  lateinit var resourceFileName: String
 
   override fun getDescription() = "Generates a local classpath resource for functional tests"
   override fun getGroup() = "build"
 
   @TaskAction
   fun doWork() {
-    val inputFiles = this.inputFiles ?: throw IllegalStateException(
-        "ClasspathWriteTask requires 'inputFiles'")
-    val resourceFileName = this.resourceFileName ?: throw IllegalStateException(
-        "ClasspathWriteTask requires 'resourceFileName'")
-    val outputDir = this.outputDir ?: throw IllegalStateException(
-        "ClasspathWriteTask requires 'outputDir'")
-
     outputDir.mkdirs()
     val outputFile = File(outputDir, resourceFileName)
     outputFile.writer(Charsets.UTF_8).use {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ android.injected.build.model.only.versioned = 3
 
 # Artifact configuration (common)
 GROUP_ID                                    = de.mannodermaus.gradle.plugins
-VERSION_NAME                                = 1.0.20
+VERSION_NAME                                = 1.1.0.0-M1-SNAPSHOT
 VCS_URL                                     = https://github.com/mannodermaus/android-junit5
 
 # Artifact configuration (plugin)
@@ -36,9 +36,9 @@ MIN_SDK_VERSION                             = 16
 TARGET_SDK_VERSION                          = 27
 
 # Dependency versions
-JUNIT_PLATFORM_VERSION                      = 1.0.2
-JUNIT_JUPITER_VERSION                       = 5.0.2
-JUNIT_VINTAGE_VERSION                       = 4.12.2
+JUNIT_PLATFORM_VERSION                      = 1.1.0-M1
+JUNIT_JUPITER_VERSION                       = 5.1.0-M1
+JUNIT_VINTAGE_VERSION                       = 5.1.0-M1
 JUNIT4_VERSION                              = 4.12
 SPOCK_VERSION                               = 1.1-groovy-2.4
 APACHE_COMMONS_VERSION                      = 2.6


### PR DESCRIPTION
* Compatibility with Java 9 Module system (probably irrelevant for Android until 202x)
* Apply default `jvmArgs`, `systemProperties` and `environment` from AGP `testOptions.unitTests` closures