### PR TITLE
Allow disabling Jacoco friend tasks based on plugin DSL

### DIFF
--- a/android-junit5/src/main/groovy/de/mannodermaus/gradle/plugins/junit5/AndroidJUnitPlatformExtension.groovy
+++ b/android-junit5/src/main/groovy/de/mannodermaus/gradle/plugins/junit5/AndroidJUnitPlatformExtension.groovy
@@ -209,11 +209,24 @@ class AndroidJUnitPlatformExtension extends JUnitPlatformExtension {
     @NonNull
     public List<String> excludedSources = []
 
+    @NonNull
+    private List<String> onlyGenerateTasksForVariants = new ArrayList<>()
+    public boolean taskGenerationEnabled = true
+
     JacocoOptions(Project project) {
       this.project = project
       this.html = new Report()
       this.csv = new Report()
       this.xml = new Report()
+    }
+
+    void onlyGenerateTasksForVariants(String... variantNames) {
+      this.onlyGenerateTasksForVariants.addAll(variantNames)
+    }
+
+    @NonNull
+    List<String> onlyGenerateTasksForVariants() {
+      return Collections.unmodifiableList(onlyGenerateTasksForVariants)
     }
 
     void html(Closure closure) {

--- a/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Plugin.kt
+++ b/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Plugin.kt
@@ -100,8 +100,15 @@ class AndroidJUnitPlatformPlugin : Plugin<Project> {
       val testTask = AndroidJUnit5UnitTest.create(this, variant, directoryProviders)
 
       if (isJacocoApplied) {
-        // Create a Jacoco friend task
-        AndroidJUnit5JacocoReport.create(this, testTask, directoryProviders)
+        val jacocoOptions = junit5.jacocoOptions
+
+        if (jacocoOptions.taskGenerationEnabled) {
+          // Create a Jacoco friend task
+          val enabledVariants = jacocoOptions.onlyGenerateTasksForVariants()
+          if (enabledVariants.isEmpty() || enabledVariants.contains(variant.name)) {
+            AndroidJUnit5JacocoReport.create(this, testTask, directoryProviders)
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
New DSL options allow consumers to restrict the automatic generation of Jacoco tasks:

```groovy
android.testOptions {
  junitPlatform {
    jacocoOptions {
      // Turn off Jacoco integration completely by setting to false; default is true
      taskGenerationEnabled = true
      // List of variants to generate Jacoco tasks for; if you have product flavors, specify the full variant names here
      onlyGenerateTasksForVariants("debug")
    }
  }
}
```

Resolves #56 