### PR TITLE
Gracefully check for JUnitPlatform before AndroidJUnit5 to avoid NoCl…

### DIFF
--- a/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Dependencies.kt
+++ b/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Dependencies.kt
@@ -99,7 +99,10 @@ class JUnit5DependencyHandler(
     return listOf(
         versions.others.instrumentationTest,
 
-        // Required at runtime
+        // Provided to instrumentation-runner at runtime,
+        // very important for the execution of JUnit 5 instrumentation tests.
+        // Also refer to AndroidJUnit5Builder's documentation for
+        // more info on how this is pieced together.
         versions.platform.runner
     )
   }

--- a/instrumentation-runner/src/main/kotlin/de/mannodermaus/junit5/RunnerBuilder.kt
+++ b/instrumentation-runner/src/main/kotlin/de/mannodermaus/junit5/RunnerBuilder.kt
@@ -33,7 +33,22 @@ class AndroidJUnit5Builder : RunnerBuilder() {
 
   private val junit5Available by lazy {
     try {
+      // The verification order of this block is quite important.
+      // Do not change it without thorough testing of potential consequences!
+      // After tampering with this, verify that integration
+      // with applications using JUnit 5 for UI tests still works,
+      // AND that integration with applications NOT using JUnit 5 for UI tests still works.
+      //
+      // First, verify the existence of junit-jupiter-api on the classpath.
+      // Then, verify that the JUnitPlatform Runner is available on the classpath.
+      // It is VERY important to perform this check BEFORE verifying the existence
+      // of the AndroidJUnit5 Runner, which inherits from JUnitPlatform. If this is omitted,
+      // an uncatchable verification error will be raised, rendering instrumentation testing
+      // for applications without the desire to include JUnit 5 effectively useless.
+      // The simple Class.forName() check however will catch this allowed inconsistency,
+      // and gracefully abort.
       Class.forName("org.junit.jupiter.api.Test")
+      Class.forName("org.junit.platform.runner.JUnitPlatform")
       Class.forName("de.mannodermaus.junit5.AndroidJUnit5")
       true
     } catch (e: Throwable) {


### PR DESCRIPTION
…assDefFoundError

Also, add thorough documentation on how these conditional runtime checks work.