### PR TITLE
Implement includeAndroidResources & returnDefaultValues API

### DIFF
--- a/android-junit5-tests/build.gradle
+++ b/android-junit5-tests/build.gradle
@@ -46,9 +46,12 @@ processTestResources {
   }
 }
 
-test.testLogging {
-  events "passed", "skipped", "failed"
-  exceptionFormat = "full"
+test {
+  failFast = true
+  testLogging {
+    events "passed", "skipped", "failed"
+    exceptionFormat = "full"
+  }
 }
 
 junitPlatform {

--- a/android-junit5-tests/src/test/groovy/de/mannodermaus/gradle/plugins/junit5/FunctionalSpec.groovy
+++ b/android-junit5-tests/src/test/groovy/de/mannodermaus/gradle/plugins/junit5/FunctionalSpec.groovy
@@ -63,225 +63,249 @@ class FunctionalSpec extends Specification {
    * ===============================================================================================
    */
 
-  def "Executes Java tests in default source set"() {
-    given:
-    androidPlugin()
-    junit5Plugin()
-    javaFile()
-    javaTest()
+//  def "Executes Java tests in default source set"() {
+//    given:
+//    androidPlugin()
+//    junit5Plugin()
+//    javaFile()
+//    javaTest()
+//
+//    when:
+//    BuildResult result = runGradle()
+//        .withArguments("build")
+//        .build()
+//
+//    then:
+//    result.task(":build").outcome == TaskOutcome.SUCCESS
+//    result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
+//    result.task(":junitPlatformTestRelease").outcome == TaskOutcome.SUCCESS
+//
+//    // 1 per build type (Debug & Release)
+//    StringUtils.countMatches(result.output, "1 tests successful") == 2
+//  }
+//
+//  def "Executes Kotlin tests in default source set"() {
+//    given:
+//    androidPlugin()
+//    kotlinPlugin()
+//    junit5Plugin()
+//    javaFile()
+//    kotlinTest()
+//
+//    when:
+//    BuildResult result = runGradle()
+//        .withArguments("build")
+//        .build()
+//
+//    then:
+//    result.task(":build").outcome == TaskOutcome.SUCCESS
+//    result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
+//    result.task(":junitPlatformTestRelease").outcome == TaskOutcome.SUCCESS
+//
+//    // 1 per build type (Debug & Release)
+//    StringUtils.countMatches(result.output, "1 tests successful") == 2
+//  }
+//
+//  def "Executes Java tests in build-type-specific source set"() {
+//    given:
+//    androidPlugin()
+//    junit5Plugin()
+//    javaFile()
+//    javaTest()
+//    javaTest(null, "debug")
+//
+//    when:
+//    BuildResult result = runGradle()
+//        .withArguments("junitPlatformTestDebug")
+//        .build()
+//
+//    then:
+//    result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
+//    result.output.contains("2 tests successful")
+//    result.output.contains("JavaDebugAdderTest")
+//    result.output.contains("JavaAdderTest")
+//
+//    when:
+//    result = runGradle()
+//        .withArguments("junitPlatformTestRelease")
+//        .build()
+//
+//    then:
+//    result.task(":junitPlatformTestRelease").outcome == TaskOutcome.SUCCESS
+//    result.output.contains("1 tests successful")
+//    result.output.contains("JavaAdderTest")
+//  }
+//
+//  def "Executes Kotlin tests in build-type-specific source set"() {
+//    given:
+//    androidPlugin()
+//    kotlinPlugin()
+//    junit5Plugin()
+//    javaFile()
+//    kotlinTest()
+//    kotlinTest(null, "debug")
+//
+//    when:
+//    BuildResult result = runGradle()
+//        .withArguments("junitPlatformTestDebug")
+//        .build()
+//
+//    then:
+//    result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
+//    result.output.contains("2 tests successful")
+//    result.output.contains("KotlinDebugAdderTest")
+//    result.output.contains("KotlinAdderTest")
+//
+//    when:
+//    result = runGradle()
+//        .withArguments("junitPlatformTestRelease")
+//        .build()
+//
+//    then:
+//    result.task(":junitPlatformTestRelease").outcome == TaskOutcome.SUCCESS
+//    result.output.contains("1 tests successful")
+//    result.output.contains("KotlinAdderTest")
+//  }
+//
+//  def "Executes Java tests in flavor-specific source set"() {
+//    given:
+//    androidPlugin(flavorNames: ["free"])
+//    junit5Plugin()
+//    javaFile()
+//    javaTest()
+//    javaTest("free", null)
+//
+//    when:
+//    BuildResult result = runGradle()
+//        .withArguments("build")
+//        .build()
+//
+//    then:
+//    result.task(":build").outcome == TaskOutcome.SUCCESS
+//    result.task(":junitPlatformTestFreeDebug").outcome == TaskOutcome.SUCCESS
+//    result.task(":junitPlatformTestFreeRelease").outcome == TaskOutcome.SUCCESS
+//
+//    // 1 per build type (Debug & Release)
+//    StringUtils.countMatches(result.output, "2 tests successful") == 2
+//  }
+//
+//  def "Executes Kotlin tests in flavor-specific source set"() {
+//    given:
+//    androidPlugin(flavorNames: ["free"])
+//    kotlinPlugin()
+//    junit5Plugin()
+//    javaFile()
+//    kotlinTest()
+//    kotlinTest("free", null)
+//
+//    when:
+//    BuildResult result = runGradle()
+//        .withArguments("build")
+//        .build()
+//
+//    then:
+//    result.task(":build").outcome == TaskOutcome.SUCCESS
+//    result.task(":junitPlatformTestFreeDebug").outcome == TaskOutcome.SUCCESS
+//    result.task(":junitPlatformTestFreeRelease").outcome == TaskOutcome.SUCCESS
+//
+//    // 1 per build type (Debug & Release)
+//    StringUtils.countMatches(result.output, "2 tests successful") == 2
+//  }
+//
+//  def "Executes Java tests in build-type-and-flavor-specific source set"() {
+//    given:
+//    androidPlugin(flavorNames: ["free"])
+//    junit5Plugin()
+//    javaFile()
+//    javaTest()
+//    javaTest(null, "debug")
+//    javaTest("free", "debug")
+//    javaTest(null, "release")
+//    GradleRunner runner = runGradle()
+//
+//    when:
+//    BuildResult result = runner
+//        .withArguments("junitPlatformTestFreeDebug")
+//        .build()
+//
+//    then:
+//    result.task(":junitPlatformTestFreeDebug").outcome == TaskOutcome.SUCCESS
+//    result.output.contains("3 tests successful")
+//    result.output.contains("JavaFreeDebugAdderTest")
+//    result.output.contains("JavaDebugAdderTest")
+//    result.output.contains("JavaAdderTest")
+//
+//    when:
+//    result = runner
+//        .withArguments("junitPlatformTestFreeRelease")
+//        .build()
+//
+//    then:
+//    result.task(":junitPlatformTestFreeRelease").outcome == TaskOutcome.SUCCESS
+//    result.output.contains("2 tests successful")
+//    result.output.contains("JavaReleaseAdderTest")
+//    result.output.contains("JavaAdderTest")
+//  }
+//
+//  def "Executes Kotlin tests in build-type-and-flavor-specific source set"() {
+//    given:
+//    androidPlugin(flavorNames: ["free"])
+//    kotlinPlugin()
+//    junit5Plugin()
+//    javaFile()
+//    kotlinTest()
+//    kotlinTest("free", "debug")
+//    kotlinTest(null, "debug")
+//    kotlinTest(null, "release")
+//    GradleRunner runner = runGradle()
+//
+//    when:
+//    BuildResult result = runner
+//        .withArguments("junitPlatformTestFreeDebug")
+//        .build()
+//
+//    then:
+//    result.task(":junitPlatformTestFreeDebug").outcome == TaskOutcome.SUCCESS
+//    result.output.contains("3 tests successful")
+//    result.output.contains("KotlinFreeDebugAdderTest")
+//    result.output.contains("KotlinDebugAdderTest")
+//    result.output.contains("KotlinAdderTest")
+//
+//    when:
+//    result = runner
+//        .withArguments("junitPlatformTestFreeRelease")
+//        .build()
+//
+//    then:
+//    result.task(":junitPlatformTestFreeRelease").outcome == TaskOutcome.SUCCESS
+//    result.output.contains("2 tests successful")
+//    result.output.contains("KotlinReleaseAdderTest")
+//    result.output.contains("KotlinAdderTest")
+//  }
 
-    when:
-    BuildResult result = runGradle()
-        .withArguments("build")
-        .build()
 
-    then:
-    result.task(":build").outcome == TaskOutcome.SUCCESS
-    result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
-    result.task(":junitPlatformTestRelease").outcome == TaskOutcome.SUCCESS
 
-    // 1 per build type (Debug & Release)
-    StringUtils.countMatches(result.output, "1 tests successful") == 2
-  }
+    def "Includes Android resources successfully"() {
+      given:
+      androidPlugin()
+      junit5Plugin("""
+        unitTests {
+          includeAndroidResources = true
+        }
+      """)
+      androidTest()
+      GradleRunner runner = runGradle()
 
-  def "Executes Kotlin tests in default source set"() {
-    given:
-    androidPlugin()
-    kotlinPlugin()
-    junit5Plugin()
-    javaFile()
-    kotlinTest()
+      when:
+      BuildResult result = runner
+          .withArguments("junitPlatformTestDebug")
+          .build()
 
-    when:
-    BuildResult result = runGradle()
-        .withArguments("build")
-        .build()
-
-    then:
-    result.task(":build").outcome == TaskOutcome.SUCCESS
-    result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
-    result.task(":junitPlatformTestRelease").outcome == TaskOutcome.SUCCESS
-
-    // 1 per build type (Debug & Release)
-    StringUtils.countMatches(result.output, "1 tests successful") == 2
-  }
-
-  def "Executes Java tests in build-type-specific source set"() {
-    given:
-    androidPlugin()
-    junit5Plugin()
-    javaFile()
-    javaTest()
-    javaTest(null, "debug")
-
-    when:
-    BuildResult result = runGradle()
-        .withArguments("junitPlatformTestDebug")
-        .build()
-
-    then:
-    result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
-    result.output.contains("2 tests successful")
-    result.output.contains("JavaDebugAdderTest")
-    result.output.contains("JavaAdderTest")
-
-    when:
-    result = runGradle()
-        .withArguments("junitPlatformTestRelease")
-        .build()
-
-    then:
-    result.task(":junitPlatformTestRelease").outcome == TaskOutcome.SUCCESS
-    result.output.contains("1 tests successful")
-    result.output.contains("JavaAdderTest")
-  }
-
-  def "Executes Kotlin tests in build-type-specific source set"() {
-    given:
-    androidPlugin()
-    kotlinPlugin()
-    junit5Plugin()
-    javaFile()
-    kotlinTest()
-    kotlinTest(null, "debug")
-
-    when:
-    BuildResult result = runGradle()
-        .withArguments("junitPlatformTestDebug")
-        .build()
-
-    then:
-    result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
-    result.output.contains("2 tests successful")
-    result.output.contains("KotlinDebugAdderTest")
-    result.output.contains("KotlinAdderTest")
-
-    when:
-    result = runGradle()
-        .withArguments("junitPlatformTestRelease")
-        .build()
-
-    then:
-    result.task(":junitPlatformTestRelease").outcome == TaskOutcome.SUCCESS
-    result.output.contains("1 tests successful")
-    result.output.contains("KotlinAdderTest")
-  }
-
-  def "Executes Java tests in flavor-specific source set"() {
-    given:
-    androidPlugin(flavorNames: ["free"])
-    junit5Plugin()
-    javaFile()
-    javaTest()
-    javaTest("free", null)
-
-    when:
-    BuildResult result = runGradle()
-        .withArguments("build")
-        .build()
-
-    then:
-    result.task(":build").outcome == TaskOutcome.SUCCESS
-    result.task(":junitPlatformTestFreeDebug").outcome == TaskOutcome.SUCCESS
-    result.task(":junitPlatformTestFreeRelease").outcome == TaskOutcome.SUCCESS
-
-    // 1 per build type (Debug & Release)
-    StringUtils.countMatches(result.output, "2 tests successful") == 2
-  }
-
-  def "Executes Kotlin tests in flavor-specific source set"() {
-    given:
-    androidPlugin(flavorNames: ["free"])
-    kotlinPlugin()
-    junit5Plugin()
-    javaFile()
-    kotlinTest()
-    kotlinTest("free", null)
-
-    when:
-    BuildResult result = runGradle()
-        .withArguments("build")
-        .build()
-
-    then:
-    result.task(":build").outcome == TaskOutcome.SUCCESS
-    result.task(":junitPlatformTestFreeDebug").outcome == TaskOutcome.SUCCESS
-    result.task(":junitPlatformTestFreeRelease").outcome == TaskOutcome.SUCCESS
-
-    // 1 per build type (Debug & Release)
-    StringUtils.countMatches(result.output, "2 tests successful") == 2
-  }
-
-  def "Executes Java tests in build-type-and-flavor-specific source set"() {
-    given:
-    androidPlugin(flavorNames: ["free"])
-    junit5Plugin()
-    javaFile()
-    javaTest()
-    javaTest(null, "debug")
-    javaTest("free", "debug")
-    javaTest(null, "release")
-    GradleRunner runner = runGradle()
-
-    when:
-    BuildResult result = runner
-        .withArguments("junitPlatformTestFreeDebug")
-        .build()
-
-    then:
-    result.task(":junitPlatformTestFreeDebug").outcome == TaskOutcome.SUCCESS
-    result.output.contains("3 tests successful")
-    result.output.contains("JavaFreeDebugAdderTest")
-    result.output.contains("JavaDebugAdderTest")
-    result.output.contains("JavaAdderTest")
-
-    when:
-    result = runner
-        .withArguments("junitPlatformTestFreeRelease")
-        .build()
-
-    then:
-    result.task(":junitPlatformTestFreeRelease").outcome == TaskOutcome.SUCCESS
-    result.output.contains("2 tests successful")
-    result.output.contains("JavaReleaseAdderTest")
-    result.output.contains("JavaAdderTest")
-  }
-
-  def "Executes Kotlin tests in build-type-and-flavor-specific source set"() {
-    given:
-    androidPlugin(flavorNames: ["free"])
-    kotlinPlugin()
-    junit5Plugin()
-    javaFile()
-    kotlinTest()
-    kotlinTest("free", "debug")
-    kotlinTest(null, "debug")
-    kotlinTest(null, "release")
-    GradleRunner runner = runGradle()
-
-    when:
-    BuildResult result = runner
-        .withArguments("junitPlatformTestFreeDebug")
-        .build()
-
-    then:
-    result.task(":junitPlatformTestFreeDebug").outcome == TaskOutcome.SUCCESS
-    result.output.contains("3 tests successful")
-    result.output.contains("KotlinFreeDebugAdderTest")
-    result.output.contains("KotlinDebugAdderTest")
-    result.output.contains("KotlinAdderTest")
-
-    when:
-    result = runner
-        .withArguments("junitPlatformTestFreeRelease")
-        .build()
-
-    then:
-    result.task(":junitPlatformTestFreeRelease").outcome == TaskOutcome.SUCCESS
-    result.output.contains("2 tests successful")
-    result.output.contains("KotlinReleaseAdderTest")
-    result.output.contains("KotlinAdderTest")
-  }
+      then:
+      result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
+      result.output.contains("1 tests successful")
+      result.output.contains("AndroidJavaAdderTest")
+    }
 
   /*
    * ===============================================================================================
@@ -357,13 +381,14 @@ class FunctionalSpec extends Specification {
     """
   }
 
-  protected final def junit5Plugin() {
+  protected final def junit5Plugin(String extraConfig = "") {
     buildFile << """
       apply plugin: "de.mannodermaus.android-junit5"
 
       android.testOptions {
         junitPlatform {
           details "flat"
+          $extraConfig
         }
       }
 
@@ -421,6 +446,28 @@ class FunctionalSpec extends Specification {
     Files.createDirectories(filePath.parent)
 
     filePath.withWriter { it.write(content.replace("__NAME__", testName)) }
+  }
+
+  protected final def androidTest(String flavorName = null, String buildType = null) {
+    this.test(language: FileLanguage.Java,
+        flavorName: flavorName,
+        buildType: buildType,
+        content: """
+          package de.mannodermaus.app;
+
+          import static org.junit.jupiter.api.Assertions.assertEquals;
+
+          import org.junit.jupiter.api.Test;
+          import android.content.Intent;
+
+          class Android__NAME__ {
+            @Test
+            void test() {
+              Intent intent = new Intent();
+              assertEquals(null, intent.getAction());
+            }
+          }
+        """)
   }
 
   protected final def javaTest(String flavorName = null, String buildType = null) {

--- a/android-junit5-tests/src/test/groovy/de/mannodermaus/gradle/plugins/junit5/FunctionalSpec.groovy
+++ b/android-junit5-tests/src/test/groovy/de/mannodermaus/gradle/plugins/junit5/FunctionalSpec.groovy
@@ -63,249 +63,301 @@ class FunctionalSpec extends Specification {
    * ===============================================================================================
    */
 
-//  def "Executes Java tests in default source set"() {
-//    given:
-//    androidPlugin()
-//    junit5Plugin()
-//    javaFile()
-//    javaTest()
-//
-//    when:
-//    BuildResult result = runGradle()
-//        .withArguments("build")
-//        .build()
-//
-//    then:
-//    result.task(":build").outcome == TaskOutcome.SUCCESS
-//    result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
-//    result.task(":junitPlatformTestRelease").outcome == TaskOutcome.SUCCESS
-//
-//    // 1 per build type (Debug & Release)
-//    StringUtils.countMatches(result.output, "1 tests successful") == 2
-//  }
-//
-//  def "Executes Kotlin tests in default source set"() {
-//    given:
-//    androidPlugin()
-//    kotlinPlugin()
-//    junit5Plugin()
-//    javaFile()
-//    kotlinTest()
-//
-//    when:
-//    BuildResult result = runGradle()
-//        .withArguments("build")
-//        .build()
-//
-//    then:
-//    result.task(":build").outcome == TaskOutcome.SUCCESS
-//    result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
-//    result.task(":junitPlatformTestRelease").outcome == TaskOutcome.SUCCESS
-//
-//    // 1 per build type (Debug & Release)
-//    StringUtils.countMatches(result.output, "1 tests successful") == 2
-//  }
-//
-//  def "Executes Java tests in build-type-specific source set"() {
-//    given:
-//    androidPlugin()
-//    junit5Plugin()
-//    javaFile()
-//    javaTest()
-//    javaTest(null, "debug")
-//
-//    when:
-//    BuildResult result = runGradle()
-//        .withArguments("junitPlatformTestDebug")
-//        .build()
-//
-//    then:
-//    result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
-//    result.output.contains("2 tests successful")
-//    result.output.contains("JavaDebugAdderTest")
-//    result.output.contains("JavaAdderTest")
-//
-//    when:
-//    result = runGradle()
-//        .withArguments("junitPlatformTestRelease")
-//        .build()
-//
-//    then:
-//    result.task(":junitPlatformTestRelease").outcome == TaskOutcome.SUCCESS
-//    result.output.contains("1 tests successful")
-//    result.output.contains("JavaAdderTest")
-//  }
-//
-//  def "Executes Kotlin tests in build-type-specific source set"() {
-//    given:
-//    androidPlugin()
-//    kotlinPlugin()
-//    junit5Plugin()
-//    javaFile()
-//    kotlinTest()
-//    kotlinTest(null, "debug")
-//
-//    when:
-//    BuildResult result = runGradle()
-//        .withArguments("junitPlatformTestDebug")
-//        .build()
-//
-//    then:
-//    result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
-//    result.output.contains("2 tests successful")
-//    result.output.contains("KotlinDebugAdderTest")
-//    result.output.contains("KotlinAdderTest")
-//
-//    when:
-//    result = runGradle()
-//        .withArguments("junitPlatformTestRelease")
-//        .build()
-//
-//    then:
-//    result.task(":junitPlatformTestRelease").outcome == TaskOutcome.SUCCESS
-//    result.output.contains("1 tests successful")
-//    result.output.contains("KotlinAdderTest")
-//  }
-//
-//  def "Executes Java tests in flavor-specific source set"() {
-//    given:
-//    androidPlugin(flavorNames: ["free"])
-//    junit5Plugin()
-//    javaFile()
-//    javaTest()
-//    javaTest("free", null)
-//
-//    when:
-//    BuildResult result = runGradle()
-//        .withArguments("build")
-//        .build()
-//
-//    then:
-//    result.task(":build").outcome == TaskOutcome.SUCCESS
-//    result.task(":junitPlatformTestFreeDebug").outcome == TaskOutcome.SUCCESS
-//    result.task(":junitPlatformTestFreeRelease").outcome == TaskOutcome.SUCCESS
-//
-//    // 1 per build type (Debug & Release)
-//    StringUtils.countMatches(result.output, "2 tests successful") == 2
-//  }
-//
-//  def "Executes Kotlin tests in flavor-specific source set"() {
-//    given:
-//    androidPlugin(flavorNames: ["free"])
-//    kotlinPlugin()
-//    junit5Plugin()
-//    javaFile()
-//    kotlinTest()
-//    kotlinTest("free", null)
-//
-//    when:
-//    BuildResult result = runGradle()
-//        .withArguments("build")
-//        .build()
-//
-//    then:
-//    result.task(":build").outcome == TaskOutcome.SUCCESS
-//    result.task(":junitPlatformTestFreeDebug").outcome == TaskOutcome.SUCCESS
-//    result.task(":junitPlatformTestFreeRelease").outcome == TaskOutcome.SUCCESS
-//
-//    // 1 per build type (Debug & Release)
-//    StringUtils.countMatches(result.output, "2 tests successful") == 2
-//  }
-//
-//  def "Executes Java tests in build-type-and-flavor-specific source set"() {
-//    given:
-//    androidPlugin(flavorNames: ["free"])
-//    junit5Plugin()
-//    javaFile()
-//    javaTest()
-//    javaTest(null, "debug")
-//    javaTest("free", "debug")
-//    javaTest(null, "release")
-//    GradleRunner runner = runGradle()
-//
-//    when:
-//    BuildResult result = runner
-//        .withArguments("junitPlatformTestFreeDebug")
-//        .build()
-//
-//    then:
-//    result.task(":junitPlatformTestFreeDebug").outcome == TaskOutcome.SUCCESS
-//    result.output.contains("3 tests successful")
-//    result.output.contains("JavaFreeDebugAdderTest")
-//    result.output.contains("JavaDebugAdderTest")
-//    result.output.contains("JavaAdderTest")
-//
-//    when:
-//    result = runner
-//        .withArguments("junitPlatformTestFreeRelease")
-//        .build()
-//
-//    then:
-//    result.task(":junitPlatformTestFreeRelease").outcome == TaskOutcome.SUCCESS
-//    result.output.contains("2 tests successful")
-//    result.output.contains("JavaReleaseAdderTest")
-//    result.output.contains("JavaAdderTest")
-//  }
-//
-//  def "Executes Kotlin tests in build-type-and-flavor-specific source set"() {
-//    given:
-//    androidPlugin(flavorNames: ["free"])
-//    kotlinPlugin()
-//    junit5Plugin()
-//    javaFile()
-//    kotlinTest()
-//    kotlinTest("free", "debug")
-//    kotlinTest(null, "debug")
-//    kotlinTest(null, "release")
-//    GradleRunner runner = runGradle()
-//
-//    when:
-//    BuildResult result = runner
-//        .withArguments("junitPlatformTestFreeDebug")
-//        .build()
-//
-//    then:
-//    result.task(":junitPlatformTestFreeDebug").outcome == TaskOutcome.SUCCESS
-//    result.output.contains("3 tests successful")
-//    result.output.contains("KotlinFreeDebugAdderTest")
-//    result.output.contains("KotlinDebugAdderTest")
-//    result.output.contains("KotlinAdderTest")
-//
-//    when:
-//    result = runner
-//        .withArguments("junitPlatformTestFreeRelease")
-//        .build()
-//
-//    then:
-//    result.task(":junitPlatformTestFreeRelease").outcome == TaskOutcome.SUCCESS
-//    result.output.contains("2 tests successful")
-//    result.output.contains("KotlinReleaseAdderTest")
-//    result.output.contains("KotlinAdderTest")
-//  }
+  def "Executes Java tests in default source set"() {
+    given:
+    androidPlugin()
+    junit5Plugin()
+    javaFile()
+    javaTest()
 
+    when:
+    BuildResult result = runGradle()
+        .withArguments("build")
+        .build()
 
+    then:
+    result.task(":build").outcome == TaskOutcome.SUCCESS
+    result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
+    result.task(":junitPlatformTestRelease").outcome == TaskOutcome.SUCCESS
 
-    def "Includes Android resources successfully"() {
-      given:
-      androidPlugin()
-      junit5Plugin("""
+    // 1 per build type (Debug & Release)
+    StringUtils.countMatches(result.output, "1 tests successful") == 2
+  }
+
+  def "Executes Kotlin tests in default source set"() {
+    given:
+    androidPlugin()
+    kotlinPlugin()
+    junit5Plugin()
+    javaFile()
+    kotlinTest()
+
+    when:
+    BuildResult result = runGradle()
+        .withArguments("build")
+        .build()
+
+    then:
+    result.task(":build").outcome == TaskOutcome.SUCCESS
+    result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
+    result.task(":junitPlatformTestRelease").outcome == TaskOutcome.SUCCESS
+
+    // 1 per build type (Debug & Release)
+    StringUtils.countMatches(result.output, "1 tests successful") == 2
+  }
+
+  def "Executes Java tests in build-type-specific source set"() {
+    given:
+    androidPlugin()
+    junit5Plugin()
+    javaFile()
+    javaTest()
+    javaTest(null, "debug")
+
+    when:
+    BuildResult result = runGradle()
+        .withArguments("junitPlatformTestDebug")
+        .build()
+
+    then:
+    result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
+    result.output.contains("2 tests successful")
+    result.output.contains("JavaDebugAdderTest")
+    result.output.contains("JavaAdderTest")
+
+    when:
+    result = runGradle()
+        .withArguments("junitPlatformTestRelease")
+        .build()
+
+    then:
+    result.task(":junitPlatformTestRelease").outcome == TaskOutcome.SUCCESS
+    result.output.contains("1 tests successful")
+    result.output.contains("JavaAdderTest")
+  }
+
+  def "Executes Kotlin tests in build-type-specific source set"() {
+    given:
+    androidPlugin()
+    kotlinPlugin()
+    junit5Plugin()
+    javaFile()
+    kotlinTest()
+    kotlinTest(null, "debug")
+
+    when:
+    BuildResult result = runGradle()
+        .withArguments("junitPlatformTestDebug")
+        .build()
+
+    then:
+    result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
+    result.output.contains("2 tests successful")
+    result.output.contains("KotlinDebugAdderTest")
+    result.output.contains("KotlinAdderTest")
+
+    when:
+    result = runGradle()
+        .withArguments("junitPlatformTestRelease")
+        .build()
+
+    then:
+    result.task(":junitPlatformTestRelease").outcome == TaskOutcome.SUCCESS
+    result.output.contains("1 tests successful")
+    result.output.contains("KotlinAdderTest")
+  }
+
+  def "Executes Java tests in flavor-specific source set"() {
+    given:
+    androidPlugin(flavorNames: ["free"])
+    junit5Plugin()
+    javaFile()
+    javaTest()
+    javaTest("free", null)
+
+    when:
+    BuildResult result = runGradle()
+        .withArguments("build")
+        .build()
+
+    then:
+    result.task(":build").outcome == TaskOutcome.SUCCESS
+    result.task(":junitPlatformTestFreeDebug").outcome == TaskOutcome.SUCCESS
+    result.task(":junitPlatformTestFreeRelease").outcome == TaskOutcome.SUCCESS
+
+    // 1 per build type (Debug & Release)
+    StringUtils.countMatches(result.output, "2 tests successful") == 2
+  }
+
+  def "Executes Kotlin tests in flavor-specific source set"() {
+    given:
+    androidPlugin(flavorNames: ["free"])
+    kotlinPlugin()
+    junit5Plugin()
+    javaFile()
+    kotlinTest()
+    kotlinTest("free", null)
+
+    when:
+    BuildResult result = runGradle()
+        .withArguments("build")
+        .build()
+
+    then:
+    result.task(":build").outcome == TaskOutcome.SUCCESS
+    result.task(":junitPlatformTestFreeDebug").outcome == TaskOutcome.SUCCESS
+    result.task(":junitPlatformTestFreeRelease").outcome == TaskOutcome.SUCCESS
+
+    // 1 per build type (Debug & Release)
+    StringUtils.countMatches(result.output, "2 tests successful") == 2
+  }
+
+  def "Executes Java tests in build-type-and-flavor-specific source set"() {
+    given:
+    androidPlugin(flavorNames: ["free"])
+    junit5Plugin()
+    javaFile()
+    javaTest()
+    javaTest(null, "debug")
+    javaTest("free", "debug")
+    javaTest(null, "release")
+    GradleRunner runner = runGradle()
+
+    when:
+    BuildResult result = runner
+        .withArguments("junitPlatformTestFreeDebug")
+        .build()
+
+    then:
+    result.task(":junitPlatformTestFreeDebug").outcome == TaskOutcome.SUCCESS
+    result.output.contains("3 tests successful")
+    result.output.contains("JavaFreeDebugAdderTest")
+    result.output.contains("JavaDebugAdderTest")
+    result.output.contains("JavaAdderTest")
+
+    when:
+    result = runner
+        .withArguments("junitPlatformTestFreeRelease")
+        .build()
+
+    then:
+    result.task(":junitPlatformTestFreeRelease").outcome == TaskOutcome.SUCCESS
+    result.output.contains("2 tests successful")
+    result.output.contains("JavaReleaseAdderTest")
+    result.output.contains("JavaAdderTest")
+  }
+
+  def "Executes Kotlin tests in build-type-and-flavor-specific source set"() {
+    given:
+    androidPlugin(flavorNames: ["free"])
+    kotlinPlugin()
+    junit5Plugin()
+    javaFile()
+    kotlinTest()
+    kotlinTest("free", "debug")
+    kotlinTest(null, "debug")
+    kotlinTest(null, "release")
+    GradleRunner runner = runGradle()
+
+    when:
+    BuildResult result = runner
+        .withArguments("junitPlatformTestFreeDebug")
+        .build()
+
+    then:
+    result.task(":junitPlatformTestFreeDebug").outcome == TaskOutcome.SUCCESS
+    result.output.contains("3 tests successful")
+    result.output.contains("KotlinFreeDebugAdderTest")
+    result.output.contains("KotlinDebugAdderTest")
+    result.output.contains("KotlinAdderTest")
+
+    when:
+    result = runner
+        .withArguments("junitPlatformTestFreeRelease")
+        .build()
+
+    then:
+    result.task(":junitPlatformTestFreeRelease").outcome == TaskOutcome.SUCCESS
+    result.output.contains("2 tests successful")
+    result.output.contains("KotlinReleaseAdderTest")
+    result.output.contains("KotlinAdderTest")
+  }
+
+  def "Returns default values successfully"() {
+    given:
+    androidPlugin()
+    junit5Plugin("""
+      unitTests {
+        returnDefaultValues = true
+      }
+    """)
+    test(language: FileLanguage.Java,
+        content: """
+        package de.mannodermaus.app;
+
+        import static org.junit.jupiter.api.Assertions.assertNull;
+
+        import org.junit.jupiter.api.Test;
+        import android.content.Intent;
+
+        class AndroidTest {
+          @Test
+          void test() {
+            Intent intent = new Intent();
+            assertNull(intent.getAction());
+          }
+        }
+      """)
+    GradleRunner runner = runGradle()
+
+    when:
+    BuildResult result = runner
+        .withArguments("junitPlatformTestDebug")
+        .build()
+
+    then:
+    result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
+    result.output.contains("1 tests successful")
+    result.output.contains("AndroidTest")
+  }
+
+  def "Includes Android resources successfully"() {
+    given:
+    androidPlugin()
+    junit5Plugin("""
         unitTests {
           includeAndroidResources = true
         }
       """)
-      androidTest()
-      GradleRunner runner = runGradle()
+    test(language: FileLanguage.Java,
+        content: """
+          package de.mannodermaus.app;
 
-      when:
-      BuildResult result = runner
-          .withArguments("junitPlatformTestDebug")
-          .build()
+          import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-      then:
-      result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
-      result.output.contains("1 tests successful")
-      result.output.contains("AndroidJavaAdderTest")
-    }
+          import org.junit.jupiter.api.Test;
+          import java.io.InputStream;
+
+          class AndroidTest {
+            @Test
+            void test() {
+              InputStream is = getClass().getResourceAsStream("/com/android/tools/test_config.properties");
+              assertNotNull(is);
+            }
+          }
+        """)
+    GradleRunner runner = runGradle()
+
+    when:
+    BuildResult result = runner
+        .withArguments("junitPlatformTestDebug")
+        .build()
+
+    then:
+    result.task(":junitPlatformTestDebug").outcome == TaskOutcome.SUCCESS
+    result.output.contains("1 tests successful")
+    result.output.contains("AndroidTest")
+  }
 
   /*
    * ===============================================================================================
@@ -446,28 +498,6 @@ class FunctionalSpec extends Specification {
     Files.createDirectories(filePath.parent)
 
     filePath.withWriter { it.write(content.replace("__NAME__", testName)) }
-  }
-
-  protected final def androidTest(String flavorName = null, String buildType = null) {
-    this.test(language: FileLanguage.Java,
-        flavorName: flavorName,
-        buildType: buildType,
-        content: """
-          package de.mannodermaus.app;
-
-          import static org.junit.jupiter.api.Assertions.assertEquals;
-
-          import org.junit.jupiter.api.Test;
-          import android.content.Intent;
-
-          class Android__NAME__ {
-            @Test
-            void test() {
-              Intent intent = new Intent();
-              assertEquals(null, intent.getAction());
-            }
-          }
-        """)
   }
 
   protected final def javaTest(String flavorName = null, String buildType = null) {

--- a/android-junit5-tests/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/PluginSpec.kt
+++ b/android-junit5-tests/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/PluginSpec.kt
@@ -466,6 +466,11 @@ class PluginSpec : Spek({
 
             project.evaluate()
 
+            it("configures the AGP setting correctly") {
+              assertThat(project.android.testOptions.unitTests.isReturnDefaultValues)
+                  .isEqualTo(state)
+            }
+
             it("generates a mockable android.jar with the correct suffix") {
               val variant = ProjectConfig(project).unitTestVariants.first()
               val file = variant.variantData.scope.globalScope.mockableAndroidJarFile
@@ -476,6 +481,25 @@ class PluginSpec : Spek({
               } else {
                 assertion.doesNotContain("default-values")
               }
+            }
+          }
+        }
+      }
+
+      context("unitTests.includeAndroidResources") {
+        val project by memoized { testProjectBuilder.build() }
+
+        listOf(true, false).forEach { state ->
+          on("set to $state") {
+            project.android.testOptions.junitPlatform.unitTests {
+              includeAndroidResources = state
+            }
+
+            project.evaluate()
+
+            it("configures the AGP setting correctly") {
+              assertThat(project.android.testOptions.unitTests.isIncludeAndroidResources)
+                  .isEqualTo(state)
             }
           }
         }

--- a/android-junit5-tests/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/PluginSpec.kt
+++ b/android-junit5-tests/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/PluginSpec.kt
@@ -455,6 +455,32 @@ class PluginSpec : Spek({
         }
       }
 
+      context("unitTests.returnDefaultValues") {
+        val project by memoized { testProjectBuilder.build() }
+
+        listOf(true, false).forEach { state ->
+          on("set to $state") {
+            project.android.testOptions.junitPlatform.unitTests {
+              returnDefaultValues = state
+            }
+
+            project.evaluate()
+
+            it("generates a mockable android.jar with the correct suffix") {
+              val variant = ProjectConfig(project).unitTestVariants.first()
+              val file = variant.variantData.scope.globalScope.mockableAndroidJarFile
+              val assertion = assertThat(file.name)
+
+              if (state) {
+                assertion.contains("default-values")
+              } else {
+                assertion.doesNotContain("default-values")
+              }
+            }
+          }
+        }
+      }
+
       context("jacoco integration") {
         beforeEachTest { testProjectBuilder.applyJacocoPlugin() }
 

--- a/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Dsl.kt
+++ b/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Dsl.kt
@@ -164,7 +164,7 @@ open class AndroidJUnitPlatformExtension(private val project: Project) {
    *
    * @since 1.0.23
    */
-  val unitTests = UnitTestOptions()
+  val unitTests = UnitTestOptions(project)
 
   /**
    * Configures unit test options
@@ -469,7 +469,7 @@ open class IncludeExcludeContainer {
 /**
  * Options for controlling how JUnit 5 Unit Tests should be executed
  */
-class UnitTestOptions {
+class UnitTestOptions(private val project: Project) {
 
   operator fun invoke(config: UnitTestOptions.() -> Unit) {
     this.config()
@@ -499,8 +499,13 @@ class UnitTestOptions {
    * values (i.e. zero or null).
    *
    * Defaults to false, which will throw exceptions on unmocked method invocations
+   *
+   * @since 1.0.32
    */
-  var returnDefaultValues = false
+  var returnDefaultValues: Boolean = false
+    set(value) {
+      project.android.testOptions.unitTests.isReturnDefaultValues = value
+    }
 
   /**
    * Enables unit tests to use Android resources, assets, and manifests.
@@ -526,8 +531,13 @@ class UnitTestOptions {
    *       modify the application ID in your build scripts, this package name may not match
    *       the <code>package</code> attribute in the final app manifest.
    * </ul>
+   *
+   * @since 1.0.32
    */
-  var includeAndroidResources = false
+  var includeAndroidResources: Boolean = false
+    set(value) {
+      project.android.testOptions.unitTests.isIncludeAndroidResources = value
+    }
 
   /**
    * Applies the provided config closure to all JUnit 5 test tasks,

--- a/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Dsl.kt
+++ b/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Dsl.kt
@@ -43,6 +43,7 @@ open class AndroidJUnitPlatformExtension(private val project: Project) {
    * The version of JUnit Platform to use
    */
   var platformVersion: String? = null
+
   fun platformVersion(version: String?) {
     this.platformVersion = version
   }
@@ -51,6 +52,7 @@ open class AndroidJUnitPlatformExtension(private val project: Project) {
    * The version of JUnit Jupiter to use
    */
   var jupiterVersion: String? = null
+
   fun jupiterVersion(version: String?) {
     this.jupiterVersion = version
   }
@@ -59,6 +61,7 @@ open class AndroidJUnitPlatformExtension(private val project: Project) {
    * The version of JUnit Vintage to use
    */
   var vintageVersion: String? = null
+
   fun vintageVersion(version: String?) {
     this.vintageVersion = version
   }
@@ -67,6 +70,7 @@ open class AndroidJUnitPlatformExtension(private val project: Project) {
    * The directory for the test report files
    */
   var reportsDir: File? = null
+
   fun reportsDir(reportsDir: File?) {
     // Work around for https://discuss.gradle.org/t/bug-in-project-file-on-windows/19917
     if (reportsDir is File) {
@@ -82,6 +86,7 @@ open class AndroidJUnitPlatformExtension(private val project: Project) {
    * system property to this value
    */
   var logManager: String? = null
+
   fun logManager(logManager: String?) {
     this.logManager = logManager
   }
@@ -90,6 +95,7 @@ open class AndroidJUnitPlatformExtension(private val project: Project) {
    * Whether or not the standard Gradle {@code test} task should be enabled
    */
   var enableStandardTestTask = false
+
   fun enableStandardTestTask(state: Boolean) {
     this.enableStandardTestTask = state
   }
@@ -98,6 +104,7 @@ open class AndroidJUnitPlatformExtension(private val project: Project) {
    * Select test execution plan details mode
    */
   var details = Details.NONE
+
   fun details(details: Details) {
     this.details = details
   }
@@ -482,9 +489,45 @@ class UnitTestOptions {
    * - environment variables
    */
   var applyDefaultTestOptions = true
+
   fun applyDefaultTestOptions(state: Boolean) {
     this.applyDefaultTestOptions = state
   }
+
+  /**
+   * Whether unmocked methods from android.jar should throw exceptions or return default
+   * values (i.e. zero or null).
+   *
+   * Defaults to false, which will throw exceptions on unmocked method invocations
+   */
+  var returnDefaultValues = false
+
+  /**
+   * Enables unit tests to use Android resources, assets, and manifests.
+   * <p>
+   * If you enable this setting, the Android Gradle Plugin performs resource, asset,
+   * and manifest merging before running your unit tests. Your tests can then inspect a file
+   * called {@code com/android/tools/test_config.properties} on the classpath, which is a Java
+   * properties file with the following keys:
+   *
+   * <ul>
+   *   <li><code>android_sdk_home</code>: the absolute path to the Android SDK.
+   *   <li><code>android_merged_resources</code>: the absolute path to the merged resources
+   *       directory, which contains all the resources from this subproject and all its
+   *       dependencies.
+   *   <li><code>android_merged_assets</code>: the absolute path to the merged assets
+   *       directory. For app subprojects, the merged assets directory contains assets from
+   *       this subproject and its dependencies. For library subprojects, the merged assets
+   *       directory contains only the assets from this subproject.
+   *   <li><code>android_merged_manifest</code>: the absolute path to the merged manifest
+   *       file. Only app subprojects merge manifests of its dependencies. So, library
+   *       subprojects won't include manifest components from their dependencies.
+   *   <li><code>android_custom_package</code>: the package name of the final R class. If you
+   *       modify the application ID in your build scripts, this package name may not match
+   *       the <code>package</code> attribute in the final app manifest.
+   * </ul>
+   */
+  var includeAndroidResources = false
 
   /**
    * Applies the provided config closure to all JUnit 5 test tasks,
@@ -535,6 +578,7 @@ class InstrumentationTestOptions {
    * Whether or not to enable support for JUnit 5 instrumentation tests
    */
   var enabled: Boolean = true
+
   fun enabled(state: Boolean) {
     this.enabled = state
   }
@@ -543,6 +587,7 @@ class InstrumentationTestOptions {
    * The version of the instrumentation companion library to use
    */
   var version: String? = null
+
   fun version(version: String?) {
     this.version = version
   }
@@ -562,6 +607,7 @@ class JacocoOptions {
    * Whether or not to enable Jacoco task integration
    */
   var taskGenerationEnabled = true
+
   fun taskGenerationEnabled(state: Boolean) {
     this.taskGenerationEnabled = state
   }
@@ -620,6 +666,7 @@ class JacocoOptions {
    * By default, this will exclude R.class & BuildConfig.class
    */
   var excludedClasses = mutableListOf("**/R.class", "**/R$*.class", "**/BuildConfig.*")
+
   fun excludedClasses(vararg classes: String) = excludedClasses.addAll(classes)
 
   /**
@@ -627,6 +674,7 @@ class JacocoOptions {
    * By default, this is an empty list
    */
   var excludedSources = mutableListOf<String>()
+
   fun excludedSources(vararg sources: String) = excludedSources.addAll(sources)
 
   class Report {
@@ -639,6 +687,7 @@ class JacocoOptions {
      * Whether or not this report should be generated
      */
     var enabled: Boolean = true
+
     fun enabled(state: Boolean) {
       this.enabled = state
     }
@@ -649,6 +698,7 @@ class JacocoOptions {
      * each variant will be assigned a distinct folder if necessary
      */
     var destination: File? = null
+
     fun destination(file: File?) {
       this.destination = file
     }

--- a/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Dsl.kt
+++ b/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Dsl.kt
@@ -502,7 +502,8 @@ class UnitTestOptions(private val project: Project) {
    *
    * @since 1.0.32
    */
-  var returnDefaultValues: Boolean = false
+  var returnDefaultValues: Boolean
+    get() = project.android.testOptions.unitTests.isReturnDefaultValues
     set(value) {
       project.android.testOptions.unitTests.isReturnDefaultValues = value
     }
@@ -534,7 +535,8 @@ class UnitTestOptions(private val project: Project) {
    *
    * @since 1.0.32
    */
-  var includeAndroidResources: Boolean = false
+  var includeAndroidResources: Boolean
+    get() = project.android.testOptions.unitTests.isIncludeAndroidResources
     set(value) {
       project.android.testOptions.unitTests.isIncludeAndroidResources = value
     }

--- a/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/UnitTest.kt
+++ b/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/UnitTest.kt
@@ -16,8 +16,10 @@ import de.mannodermaus.gradle.plugins.junit5.variantData
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.file.IdentityFileResolver
 import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.Optional
@@ -64,6 +66,12 @@ open class AndroidJUnit5UnitTest : JavaExec(), JUnit5UnitTest {
   @InputFiles
   @Optional
   var assetsCollection: Set<File>? = null
+
+  @Input
+  var sdkPlatformDirPath: String? = null
+
+  @InputFiles
+  var mergedManifest: FileCollection? = null
 
   override val isRunAllTask = false
 
@@ -137,7 +145,7 @@ open class AndroidJUnit5UnitTest : JavaExec(), JUnit5UnitTest {
       defaultJUnit5Task.dependsOn(task)
 
       // Apply additional user configuration
-      project.android.testOptions.junitPlatform.unitTests.applyConfiguration(task)
+      junit5.unitTests.applyConfiguration(task)
     }
 
     /* Private */
@@ -190,6 +198,8 @@ open class AndroidJUnit5UnitTest : JavaExec(), JUnit5UnitTest {
       val variantUnitTestTask = this.getDefaultJUnit4Task()
       task.resCollection = variantUnitTestTask.resCollection?.files
       task.assetsCollection = variantUnitTestTask.safeAssetsCollection
+      task.sdkPlatformDirPath = variantUnitTestTask.sdkPlatformDirPath
+      task.mergedManifest = variantUnitTestTask.mergedManifest
 
       variantUnitTestTask.enabled = junit5.enableStandardTestTask
       variantUnitTestTask.dependsOn(task)

--- a/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/UnitTest.kt
+++ b/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/UnitTest.kt
@@ -16,7 +16,6 @@ import de.mannodermaus.gradle.plugins.junit5.variantData
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.file.IdentityFileResolver
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.tasks.InputFiles
@@ -39,6 +38,12 @@ private const val VERIFICATION_GROUP = JavaBasePlugin.VERIFICATION_GROUP
 open class AndroidJUnit5UnitTest : JavaExec(), JUnit5UnitTest {
 
   companion object {
+    fun find(project: Project, variant: BaseVariant): AndroidJUnit5UnitTest {
+      return project.tasks.getByName(
+          variant.variantData.scope.getTaskName(TASK_NAME_DEFAULT))
+          as AndroidJUnit5UnitTest
+    }
+
     fun create(
         project: Project,
         variant: BaseVariant,


### PR DESCRIPTION
This brings parity with the AGP's `UnitTestOptions` by adding these two methods for configuration of JUnit 5 test tasks. Behind the scenes, they just forward the configuration to the JUnit 4 infrastructure, since that's what the AGP uses for its internal setup.