### PR TITLE
Manually include Kotlin class folders

### DIFF
--- a/android-junit5-tests/src/test/groovy/de/mannodermaus/gradle/plugins/junit5/FunctionalSpec.groovy
+++ b/android-junit5-tests/src/test/groovy/de/mannodermaus/gradle/plugins/junit5/FunctionalSpec.groovy
@@ -192,8 +192,8 @@ class FunctionalSpec extends Specification {
   def "Executes Kotlin tests in flavor-specific source set"() {
     given:
     androidPlugin(flavorNames: ["free"])
-    kotlinPlugin()
     junit5Plugin()
+    kotlinPlugin()
     javaFile()
     kotlinTest()
     kotlinTest("free", null)

--- a/android-junit5-tests/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/PluginSpec.kt
+++ b/android-junit5-tests/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/PluginSpec.kt
@@ -508,10 +508,10 @@ class PluginSpec : Spek({
         }
       }
 
-      context("Test directory detection") {
-        // The order of applying the Kotlin plugin shoudln't interfere
+      context("test folder detection") {
+        // The order of applying the Kotlin plugin shouldn't interfere
         // with the detection of its source directories
-        // https://github.com/mannodermaus/android-junit5/issues/72
+        // (https://github.com/mannodermaus/android-junit5/issues/72)
         beforeEachTest { testProjectBuilder.applyKotlinPlugin() }
 
         listOf("debug", "release").forEach { buildType ->
@@ -529,7 +529,7 @@ class PluginSpec : Spek({
                 JavaDirectoryProvider(variant!!),
                 KotlinDirectoryProvider(project, variant)).forEach { provider ->
 
-              it(" all class folders for the ${provider.javaClass.simpleName}") {
+              it("contains all class folders of the ${provider.javaClass.simpleName}") {
                 assertThat(folders).containsAll(provider.classDirectories().map { it.absolutePath })
               }
             }


### PR DESCRIPTION
This fixes #72, wherein Kotlin folders aren't properly picked up if the JUnit 5 plugin is applied _before_ the Kotlin plugin. In that case, we can't access `KotlinCompile` tasks after evaluation, since we're asked to set up before Kotlin gets a chance.

Maybe there's a more elegant way to defer our setup until after Kotlin is done doing its thing (let's monitor potential responses to [this tweet](https://twitter.com/marcelschnelle/status/984808960829014017))