### PR TITLE
Enable Jacoco Code Previews

### DIFF
--- a/android-junit5-tests/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/PluginSpec.kt
+++ b/android-junit5-tests/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/PluginSpec.kt
@@ -519,7 +519,8 @@ class PluginSpec : Spek({
           on("assembling the $buildType task") {
             val project = testProjectBuilder.buildAndEvaluate()
             val projectConfig = ProjectConfig(project)
-            val task = project.tasks.get<AndroidJUnit5UnitTest>("junitPlatformTest${buildType.capitalize()}")
+            val task = project.tasks.get<AndroidJUnit5UnitTest>(
+                "junitPlatformTest${buildType.capitalize()}")
             val folders = argument(task, "--scan-class-path")?.split(":") ?: listOf()
 
             val variant = projectConfig.unitTestVariants.find { it.name == buildType }
@@ -556,6 +557,22 @@ class PluginSpec : Spek({
                   .contains("jacocoTestReport${buildType.capitalize()}")
             }
 
+            it("includes Main-scoped source dirs for the $buildType build type") {
+              // Expected items: "src/main/java" & "src/<TypeName>/java"
+              val sourceDirs = project.tasks.get<AndroidJUnit5JacocoReport>(
+                  "jacocoTestReport${buildType.capitalize()}")
+                  .sourceDirectories
+                  .map { it.absolutePath }
+
+              val mainDir = sourceDirs.find { it.endsWith("src/main/java") }
+              val typeDir = sourceDirs.find { it.endsWith("src/$buildType/java") }
+              assertAll(
+                  "Mismatch! Actual dirs: $sourceDirs",
+                  { assertThat(mainDir).withFailMessage("main").isNotNull() },
+                  { assertThat(typeDir).withFailMessage(buildType).isNotNull() }
+              )
+            }
+
             it("doesn't include Test-scoped source dirs for the $buildType build type") {
               // Expected omissions: "src/test/java" & "src/test<TypeName>/java"
               val sourceDirs = project.tasks.get<AndroidJUnit5JacocoReport>(
@@ -563,6 +580,7 @@ class PluginSpec : Spek({
                   .sourceDirectories.asPath
 
               assertAll(
+                  "Mismatch! Actual dirs: $sourceDirs",
                   { assertThat(sourceDirs).doesNotContain("src/test/java") },
                   {
                     assertThat(sourceDirs).doesNotContain("src/test${buildType.capitalize()}/java")

--- a/android-junit5-tests/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/PluginSpec.kt
+++ b/android-junit5-tests/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/PluginSpec.kt
@@ -724,7 +724,6 @@ class PluginSpec : Spek({
               project.android.testOptions.junitPlatform {
                 jacocoOptions {
                   excludedClasses.add("Second*.class")
-                  excludedSources.add("AnnoyingFile.java")
                 }
               }
 
@@ -765,42 +764,6 @@ class PluginSpec : Spek({
                         "R.class",
                         "FirstFile.class",
                         "SecondFile.class")
-              }
-
-              it("honors the debug source exclusion rules") {
-                // Should be included:
-                //  * OkFile.java
-                // Should be excluded:
-                //  * AnnoyingFile.java (through rule)
-                //  * ReleaseOnlyFile.java (other source set)
-                val fileNames = project.tasks.get<AndroidJUnit5JacocoReport>(
-                    "jacocoTestReportDebug")
-                    .sourceDirectories.asFileTree.files
-                    .map { it.name }
-
-                assertThat(fileNames)
-                    .contains("OkFile.java")
-                    .doesNotContain(
-                        "AnnoyingFile.java",
-                        "ReleaseOnlyFile.java")
-              }
-
-              it("honors the release source exclusion rules") {
-                // Should be included:
-                //  * OkFile.java
-                //  * ReleaseOnly.java
-                // Should be excluded:
-                //  * AnnoyingFile.java (through rule)
-                val fileNames = project.tasks.get<AndroidJUnit5JacocoReport>(
-                    "jacocoTestReportRelease")
-                    .sourceDirectories.asFileTree.files
-                    .map { it.name }
-
-                assertThat(fileNames)
-                    .contains(
-                        "OkFile.java",
-                        "ReleaseOnlyFile.java")
-                    .doesNotContain("AnnoyingFile.java")
               }
             }
 

--- a/android-junit5-tests/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/TestExtensions.kt
+++ b/android-junit5-tests/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/TestExtensions.kt
@@ -43,6 +43,10 @@ fun assertAll(vararg assertions: () -> Unit) {
   Assertions.assertAll(*assertions.map { Executable { it() } }.toTypedArray())
 }
 
+fun assertAll(heading: String, vararg assertions: () -> Unit) {
+  Assertions.assertAll(heading, *assertions.map { Executable { it() } }.toTypedArray())
+}
+
 /* Extensions */
 
 fun Project.evaluate() {

--- a/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Dsl.kt
+++ b/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Dsl.kt
@@ -681,14 +681,6 @@ class JacocoOptions {
 
   fun excludedClasses(vararg classes: String) = excludedClasses.addAll(classes)
 
-  /**
-   * List of source name patterns that should be excluded from being processed by Jacoco.
-   * By default, this is an empty list
-   */
-  var excludedSources = mutableListOf<String>()
-
-  fun excludedSources(vararg sources: String) = excludedSources.addAll(sources)
-
   class Report {
 
     operator fun invoke(config: Report.() -> Unit) {

--- a/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/Jacoco.kt
+++ b/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/Jacoco.kt
@@ -76,8 +76,7 @@ open class AndroidJUnit5JacocoReport : JacocoReport() {
       // using the sum of all DirectoryProviders' outputs as a foundation:
       reportTask.classDirectories = directoryProviders.mainClassDirectories()
           .toFileCollectionExcluding(junit5Jacoco.excludedClasses)
-      reportTask.sourceDirectories = directoryProviders.mainSourceDirectories()
-          .toFileCollectionExcluding(junit5Jacoco.excludedSources)
+      reportTask.sourceDirectories = project.files(directoryProviders.mainSourceDirectories())
 
       project.logger.junit5Info(
           "Assembled Jacoco Code Coverage for JUnit 5 Task '${testTask.name}':")


### PR DESCRIPTION
This is a bug fix for missing Code Previews in Jacoco reports (i.e. you can't click on classes to preview its source code & the coverage).