### PR TITLE
Remove support for com.android.test plugin

### DIFF
--- a/android-junit5-tests/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/PluginSpec.kt
+++ b/android-junit5-tests/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/PluginSpec.kt
@@ -40,12 +40,12 @@ class PluginSpec : Spek({
   describe("a misconfigured project") {
     val testProjectBuilder by memoized { factory.newProject(testRoot) }
 
-    on("not applying any Android plugin") {
+    on("not applying any supported Android plugin") {
       val expect = throws<PluginApplicationException> { testProjectBuilder.build() }
 
       it("throws an error") {
         assertThat(expect.cause?.message)
-            .isEqualTo("An Android plugin must be applied to this project")
+            .contains("One of the following plugins must be applied to this project")
       }
     }
 
@@ -99,7 +99,7 @@ class PluginSpec : Spek({
 
         it("adds a general-purpose filter to the JUnit 5 extension point") {
           val extension = ju5.extensionByName<FiltersExtension>("filters")
-          assertThat(extension).isNotNull()
+          assertThat(extension).isNotNull
           assertThat(ju5.filters).isEqualTo(extension)
           assertThat(ju5.findFilters()).isEqualTo(extension)
           assertThat(ju5.findFilters(qualifier = null)).isEqualTo(extension)
@@ -115,7 +115,7 @@ class PluginSpec : Spek({
 
           it("adds a $buildType-specific filter to the JUnit 5 extension point") {
             val extension = ju5.extensionByName<FiltersExtension>("${buildType}Filters")
-            assertThat(extension).isNotNull()
+            assertThat(extension).isNotNull
             assertThat(ju5.findFilters(qualifier = buildType)).isEqualTo(extension)
           }
         }
@@ -162,7 +162,7 @@ class PluginSpec : Spek({
         listOf("free", "paid").forEach { flavor ->
           it("adds a $flavor-specific filter to the JUnit 5 extension point") {
             val extension = ju5.extensionByName<FiltersExtension>("${flavor}Filters")
-            assertThat(extension).isNotNull()
+            assertThat(extension).isNotNull
             assertThat(ju5.findFilters(qualifier = flavor)).isEqualTo(extension)
           }
 
@@ -171,7 +171,7 @@ class PluginSpec : Spek({
 
             it("adds a $variantName-specific filter to the JUnit 5 extension point") {
               val extension = ju5.extensionByName<FiltersExtension>("${variantName}Filters")
-              assertThat(extension).isNotNull()
+              assertThat(extension).isNotNull
               assertThat(ju5.findFilters(qualifier = variantName)).isEqualTo(extension)
             }
           }

--- a/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Configuration.kt
+++ b/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Configuration.kt
@@ -4,15 +4,10 @@ import com.android.build.gradle.AppExtension
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.FeatureExtension
 import com.android.build.gradle.LibraryExtension
-import com.android.build.gradle.TestExtension
 import com.android.build.gradle.api.ApplicationVariant
 import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.api.LibraryVariant
-import de.mannodermaus.gradle.plugins.junit5.Type.Application
-import de.mannodermaus.gradle.plugins.junit5.Type.DynamicFeature
-import de.mannodermaus.gradle.plugins.junit5.Type.Feature
-import de.mannodermaus.gradle.plugins.junit5.Type.Library
-import de.mannodermaus.gradle.plugins.junit5.Type.Test
+import de.mannodermaus.gradle.plugins.junit5.Type.*
 import de.mannodermaus.gradle.plugins.junit5.internal.android
 import de.mannodermaus.gradle.plugins.junit5.internal.hasPlugin
 import org.gradle.api.DomainObjectSet
@@ -45,11 +40,6 @@ private sealed class Type<in T : BaseExtension>(val pluginId: String) {
         extension.applicationVariants
   }
 
-  object Test : Type<TestExtension>("com.android.test") {
-    override fun variants(extension: TestExtension): DomainObjectSet<ApplicationVariant> =
-        extension.applicationVariants
-  }
-
   object Library : Type<LibraryExtension>("com.android.library") {
     override fun variants(extension: LibraryExtension): DomainObjectSet<LibraryVariant> {
       return extension.libraryVariants
@@ -66,12 +56,12 @@ private sealed class Type<in T : BaseExtension>(val pluginId: String) {
 
   object DynamicFeature : Type<AppExtension>("com.android.dynamic-feature") {
     override fun variants(extension: AppExtension): DomainObjectSet<ApplicationVariant> =
-            extension.applicationVariants
+        extension.applicationVariants
   }
 }
 
 private val allTypes: List<Type<*>> =
-    listOf(Application, Test, Library, Feature, DynamicFeature)
+    listOf(Application, Library, Feature, DynamicFeature)
 
 @Suppress("UNCHECKED_CAST")
 private fun findType(project: Project): Type<BaseExtension> {
@@ -80,8 +70,8 @@ private fun findType(project: Project): Type<BaseExtension> {
   }
 
   if (type == null) {
-    @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
-    throw ProjectConfigurationException("An Android plugin must be applied to this project", IllegalArgumentException())
+    val supportedPluginNames = allTypes.map { it.pluginId }
+    throw ProjectConfigurationException("One of the following plugins must be applied to this project: $supportedPluginNames", IllegalArgumentException())
   } else {
     return type as Type<BaseExtension>
   }


### PR DESCRIPTION
This particular plugin describes a project without any unit test support. Since this plugin configures unit test tasks for JUnit 5, there's nothing to do for these "UI-test-only" projects.