### PR TITLE
Fix string interpolation

### DIFF
--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -63,7 +63,7 @@ android {
 
   // Add Kotlin source directory to all source sets
   sourceSets.forEach {
-    it.java.srcDir("src/$it.name/kotlin")
+    it.java.srcDir("src/${it.name}/kotlin")
   }
 
   compileOptions {


### PR DESCRIPTION
`$it.name` works just fine in Groovy, but in Kotlin this is considered a complex string template and requires brackets, i.e. `${it.name}`.