### PR TITLE
Finish dependency revisions for new instrumentation libs

### DIFF
--- a/buildSrc/src/main/kotlin/Artifacts.kt
+++ b/buildSrc/src/main/kotlin/Artifacts.kt
@@ -72,7 +72,7 @@ object Artifacts {
     val Runner = Deployed(
         platform = Android(minSdk = 14),
         groupId = groupId,
-        artifactId = "android-instrumentation-test-runner",
+        artifactId = "android-test-runner",
         currentVersion = currentVersion,
         latestStableVersion = latestStableVersion,
         license = license,

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -15,10 +15,10 @@ object Versions {
 
     const val aapt2: String = "3.2.1-4818971" 
 
-    const val com_android_tools_build_gradle: String = "3.4.0-rc02"
+    const val com_android_tools_build_gradle: String = "3.4.0-rc03"
     const val com_android_tools_build_gradle_32x: String = "3.2.1"
     const val com_android_tools_build_gradle_33x: String = "3.3.2"
-    const val com_android_tools_build_gradle_34x: String = "3.4.0-rc02"
+    const val com_android_tools_build_gradle_34x: String = "3.4.0-rc03"
     const val com_android_tools_build_gradle_35x: String = "3.5.0-alpha07"
 
     const val lint_gradle: String = "26.2.1" 

--- a/instrumentation/core/build.gradle.kts
+++ b/instrumentation/core/build.gradle.kts
@@ -81,14 +81,15 @@ tasks.withType<Test> {
 }
 
 dependencies {
-  implementation(Libs.junit_jupiter_api)
   implementation(Libs.kotlin_stdlib)
-  implementation(Libs.androidx_test_core)
+  implementation(Libs.junit_jupiter_api)
+  api(Libs.androidx_test_core)
 
   // This is required by the "instrumentation-runner" companion library,
   // since it can't provide any JUnit 5 runtime libraries itself
   // due to fear of prematurely incrementing the minSdkVersion requirement.
   runtimeOnly(Libs.junit_platform_runner)
+  runtimeOnly(Libs.junit_jupiter_engine)
 
   androidTestImplementation(Libs.junit_jupiter_api)
   androidTestImplementation(Libs.espresso_core)

--- a/instrumentation/sample/build.gradle.kts
+++ b/instrumentation/sample/build.gradle.kts
@@ -1,5 +1,6 @@
 import de.mannodermaus.gradle.plugins.junit5.junitPlatform
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
   repositories {
@@ -65,6 +66,12 @@ android {
   }
 }
 
+tasks.withType<KotlinCompile> {
+  kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_1_8.toString()
+  }
+}
+
 tasks.withType<Test> {
   testLogging.events = setOf(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
 }
@@ -81,8 +88,8 @@ dependencies {
 
   // Android Instrumentation Tests wth JUnit 5
   androidTestImplementation(Libs.junit_jupiter_api)
-  androidTestRuntimeOnly(Libs.junit_jupiter_engine)
-  androidTestRuntimeOnly(Libs.junit_platform_runner)
-  androidTestImplementation(project(":api"))
+  androidTestImplementation(Libs.junit_jupiter_params)
+  androidTestImplementation(Libs.espresso_core)
+  androidTestImplementation(project(":core"))
   androidTestRuntimeOnly(project(":runner"))
 }

--- a/instrumentation/sample/src/androidTest/kotlin/de/mannodermaus/sample/ActivityOneTest.kt
+++ b/instrumentation/sample/src/androidTest/kotlin/de/mannodermaus/sample/ActivityOneTest.kt
@@ -1,0 +1,59 @@
+package de.mannodermaus.sample
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import de.mannodermaus.junit5.ActivityScenarioExtension
+import de.mannodermaus.junit5.sample.ActivityOne
+import de.mannodermaus.junit5.sample.R
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.RepetitionInfo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class ActivityOneTest {
+
+  @JvmField
+  @RegisterExtension
+  val scenarioExtension = ActivityScenarioExtension.launch<ActivityOne>()
+
+  @Test
+  fun testExample(scenario: ActivityScenario<ActivityOne>) {
+    onView(withId(R.id.textView)).check(matches(withText("0")))
+  }
+
+  @ValueSource(strings = ["value1", "value2"])
+  @ParameterizedTest
+  fun parameterizedTestExample(value: String, scenario: ActivityScenario<ActivityOne>) {
+    scenario.onActivity {
+      assertEquals(0, it.getClickCount())
+      it.setButtonLabel(value)
+    }
+
+    onView(withId(R.id.button)).check(matches(withText(value)))
+    onView(withId(R.id.button)).perform(click())
+
+    scenario.onActivity {
+      assertEquals(1, it.getClickCount())
+    }
+  }
+
+  @RepeatedTest(3)
+  fun repeatedTestExample(repetitionInfo: RepetitionInfo, scenario: ActivityScenario<ActivityOne>) {
+    val count = repetitionInfo.currentRepetition
+
+    for (i in 0 until count) {
+      onView(withId(R.id.button)).perform(click())
+    }
+
+    scenario.onActivity {
+      assertEquals(count, it.getClickCount())
+    }
+  }
+}

--- a/instrumentation/sample/src/main/kotlin/de/mannodermaus/junit5/sample/ActivityOne.kt
+++ b/instrumentation/sample/src/main/kotlin/de/mannodermaus/junit5/sample/ActivityOne.kt
@@ -1,7 +1,31 @@
 package de.mannodermaus.junit5.sample
 
 import android.app.Activity
+import android.os.Bundle
+import android.widget.Button
+import android.widget.TextView
 
 class ActivityOne : Activity() {
 
+  private val textView by lazy { findViewById<TextView>(R.id.textView) }
+  private val button by lazy { findViewById<Button>(R.id.button) }
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_one)
+
+    button.setOnClickListener {
+      val currentClickCount = getClickCount()
+      val newClickCount = currentClickCount + 1
+      textView.text = newClickCount.toString()
+    }
+  }
+
+  fun getClickCount(): Int {
+    return textView.text.toString().toInt()
+  }
+
+  fun setButtonLabel(newText: String) {
+    button.text = newText
+  }
 }

--- a/instrumentation/sample/src/main/res/layout/activity_one.xml
+++ b/instrumentation/sample/src/main/res/layout/activity_one.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:gravity="center"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
+
+    <TextView
+            android:id="@+id/textView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="0"/>
+
+    <Button
+            android:id="@+id/button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Click"/>
+</LinearLayout>


### PR DESCRIPTION
I feel like the integration is really smooth now. Once this is done, I'll test against another reference project through the actual Maven coordinates, and after that we should be good to go with the inaugural release. That's also when I'll attend to writing the guides on this stuff, too.

Final artifacts:
- `de.mannodermaus.junit5:android-test-core`
- `de.mannodermaus.junit5:android-test-runner`

Final integration:
```kotlin
dependencies {
  // Required for all tests
  androidTestImplementation("androidx.test:runner:...")
  // If you want...
  androidTestImplementation("androidx.test.espresso:espresso-core:...")
  // Required for JUnit 5 tests
  androidTestImplementation("org.junit.jupiter:junit-jupiter-api:...")

  // NEW: Required for JUnit 5 instrumentation tests
  androidTestImplementation("de.mannodermaus.junit5:android-test-core:...")
  androidTestRuntimeOnly("de.mannodermaus.junit5:android-test-runner:...")
}
```