### PR TITLE
Gradle 5.4.1 & tests for Android Gradle Plugin 3.6

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -37,6 +37,8 @@ object Libs {
     Versions.com_android_tools_build_gradle_34x
     const val com_android_tools_build_gradle_35x: String = "com.android.tools.build:gradle:" +
         Versions.com_android_tools_build_gradle_35x
+    const val com_android_tools_build_gradle_36x: String = "com.android.tools.build:gradle:" +
+        Versions.com_android_tools_build_gradle_36x
 
     /**
      * https://developer.android.com/studio */

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -15,11 +15,12 @@ object Versions {
 
     const val aapt2: String = "3.2.1-4818971" 
 
-    const val com_android_tools_build_gradle: String = "3.4.0"
+    const val com_android_tools_build_gradle: String = "3.4.1"
     const val com_android_tools_build_gradle_32x: String = "3.2.1"
     const val com_android_tools_build_gradle_33x: String = "3.3.2"
-    const val com_android_tools_build_gradle_34x: String = "3.4.0"
-    const val com_android_tools_build_gradle_35x: String = "3.5.0-alpha13"
+    const val com_android_tools_build_gradle_34x: String = "3.4.1"
+    const val com_android_tools_build_gradle_35x: String = "3.5.0-beta03"
+    const val com_android_tools_build_gradle_36x: String = "3.6.0-alpha02"
 
     const val lint_gradle: String = "26.2.1" 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/android-junit5/build.gradle.kts
+++ b/plugin/android-junit5/build.gradle.kts
@@ -71,6 +71,7 @@ tasks.named("processTestResources", Copy::class.java).configure {
       "AGP_33X" to Versions.com_android_tools_build_gradle_33x,
       "AGP_34X" to Versions.com_android_tools_build_gradle_34x,
       "AGP_35X" to Versions.com_android_tools_build_gradle_35x,
+      "AGP_36X" to Versions.com_android_tools_build_gradle_36x,
       "KOTLIN" to Versions.org_jetbrains_kotlin,
 
       "JUPITER_API" to Libs.junit_jupiter_api,
@@ -116,7 +117,8 @@ private val agpConfigurations = listOf(
     AgpConfiguration("3.2", Libs.com_android_tools_build_gradle_32x),
     AgpConfiguration("3.3", Libs.com_android_tools_build_gradle_33x),
     AgpConfiguration("3.4", Libs.com_android_tools_build_gradle_34x),
-    AgpConfiguration("3.5", Libs.com_android_tools_build_gradle_35x)
+    AgpConfiguration("3.5", Libs.com_android_tools_build_gradle_35x),
+    AgpConfiguration("3.6", Libs.com_android_tools_build_gradle_36x)
 )
 
 configurations {

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/FunctionalTests.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/FunctionalTests.kt
@@ -125,6 +125,40 @@ class FunctionalTests {
   }
 
   @Test
+  @DisplayName("Android Gradle Plugin 3.6.x, with Flavors and Build Types")
+  fun agp36x() {
+    val fixtureRoot = File("src/test/projects/agp36x")
+    File(fixtureRoot, "build").deleteRecursively()
+
+    val result = runGradle(AgpVersion.AGP_36X)
+        .withProjectDir(fixtureRoot)
+        .build()
+
+    assertThat(result).task(":test")
+        .hasOutcome(TaskOutcome.SUCCESS)
+    assertThat(result).output().ofTask(":testFreeDebugUnitTest").apply {
+      contains("de.mannodermaus.app.JavaTest > test() PASSED")
+      executedTestCount().isEqualTo(1)
+    }
+    assertThat(result).output().ofTask(":testFreeReleaseUnitTest").apply {
+      contains("de.mannodermaus.app.JavaTest > test() PASSED")
+      contains("de.mannodermaus.app.KotlinReleaseTest > test() PASSED")
+      contains("de.mannodermaus.app.JavaFreeReleaseTest > test() PASSED")
+      executedTestCount().isEqualTo(3)
+    }
+    assertThat(result).output().ofTask(":testPaidDebugUnitTest").apply {
+      contains("de.mannodermaus.app.JavaTest > test() PASSED")
+      contains("de.mannodermaus.app.KotlinPaidDebugTest > test() PASSED")
+      executedTestCount().isEqualTo(2)
+    }
+    assertThat(result).output().ofTask(":testPaidReleaseUnitTest").apply {
+      contains("de.mannodermaus.app.JavaTest > test() PASSED")
+      contains("de.mannodermaus.app.KotlinReleaseTest > test() PASSED")
+      executedTestCount().isEqualTo(2)
+    }
+  }
+
+  @Test
   @DisplayName("Return Android default values")
   fun androidDefaultValues() {
     val fixtureRoot = File("src/test/projects/default-values")

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/AgpVersion.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/AgpVersion.kt
@@ -4,7 +4,8 @@ enum class AgpVersion(val fileKey: String) {
   AGP_32X("agp32x"),
   AGP_33X("agp33x"),
   AGP_34X("agp34x"),
-  AGP_35X("agp35x");
+  AGP_35X("agp35x"),
+  AGP_36X("agp36x");
 
   companion object {
     fun latest() = AGP_34X

--- a/plugin/android-junit5/src/test/projects/agp36x/build.gradle
+++ b/plugin/android-junit5/src/test/projects/agp36x/build.gradle
@@ -1,0 +1,46 @@
+buildscript {
+  repositories {
+    google()
+    jcenter()
+  }
+}
+
+plugins {
+  id "com.android.application"
+  id "org.jetbrains.kotlin.android"
+  id "de.mannodermaus.android-junit5"
+  id "jacoco"
+}
+
+def version = com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION
+if (version != AGP_36X) {
+  throw new IllegalStateException("Incorrect AGP version. Expected $AGP_36X, got $version")
+}
+
+repositories {
+  google()
+  jcenter()
+}
+
+android {
+  compileSdkVersion COMPILE_SDK_VERSION
+
+  flavorDimensions "environment"
+  productFlavors {
+    free {
+      dimension "environment"
+    }
+    paid {
+      dimension "environment"
+    }
+  }
+
+  testOptions.unitTests.all {
+    testLogging.events = ["passed", "skipped", "failed"]
+  }
+}
+
+dependencies {
+  testImplementation JUPITER_API
+  testRuntimeOnly JUPITER_ENGINE
+}

--- a/plugin/android-junit5/src/test/projects/agp36x/settings.gradle
+++ b/plugin/android-junit5/src/test/projects/agp36x/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+  repositories {
+    google()
+  }
+  resolutionStrategy {
+    eachPlugin {
+      if (requested.id.id == "com.android.application") {
+        useModule("com.android.tools.build:gradle:$AGP_36X")
+      }
+      if (requested.id.id == "org.jetbrains.kotlin.android") {
+        useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN")
+      }
+    }
+  }
+}

--- a/plugin/android-junit5/src/test/projects/agp36x/src/main/AndroidManifest.xml
+++ b/plugin/android-junit5/src/test/projects/agp36x/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="de.mannodermaus.app"></manifest>

--- a/plugin/android-junit5/src/test/projects/agp36x/src/main/java/de/mannodermaus/app/Adder.java
+++ b/plugin/android-junit5/src/test/projects/agp36x/src/main/java/de/mannodermaus/app/Adder.java
@@ -1,0 +1,7 @@
+package de.mannodermaus.app;
+
+public class Adder {
+  public int add(int a, int b) {
+    return a + b;
+  }
+}

--- a/plugin/android-junit5/src/test/projects/agp36x/src/test/java/de/mannodermaus/app/JavaTest.java
+++ b/plugin/android-junit5/src/test/projects/agp36x/src/test/java/de/mannodermaus/app/JavaTest.java
@@ -1,0 +1,13 @@
+package de.mannodermaus.app;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class JavaTest {
+  @Test
+  void test() {
+    Adder adder = new Adder();
+    assertEquals(4, adder.add(2, 2), "This should succeed!");
+  }
+}

--- a/plugin/android-junit5/src/test/projects/agp36x/src/testFreeRelease/java/de/mannodermaus/app/JavaFreeReleaseTest.java
+++ b/plugin/android-junit5/src/test/projects/agp36x/src/testFreeRelease/java/de/mannodermaus/app/JavaFreeReleaseTest.java
@@ -1,0 +1,13 @@
+package de.mannodermaus.app;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class JavaFreeReleaseTest {
+  @Test
+  void test() {
+    Adder adder = new Adder();
+    assertEquals(4, adder.add(2, 2), "This should succeed!");
+  }
+}

--- a/plugin/android-junit5/src/test/projects/agp36x/src/testPaidDebug/java/de/mannodermaus/app/KotlinPaidDebugTest.kt
+++ b/plugin/android-junit5/src/test/projects/agp36x/src/testPaidDebug/java/de/mannodermaus/app/KotlinPaidDebugTest.kt
@@ -1,0 +1,12 @@
+package de.mannodermaus.app
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class KotlinPaidDebugTest {
+  @Test
+  fun test() {
+    val adder = Adder()
+    assertEquals(4, adder.add(2, 2), "This should succeed!")
+  }
+}

--- a/plugin/android-junit5/src/test/projects/agp36x/src/testRelease/java/de/mannodermaus/app/KotlinReleaseTest.kt
+++ b/plugin/android-junit5/src/test/projects/agp36x/src/testRelease/java/de/mannodermaus/app/KotlinReleaseTest.kt
@@ -1,0 +1,12 @@
+package de.mannodermaus.app
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class KotlinReleaseTest {
+  @Test
+  fun test() {
+    val adder = Adder()
+    assertEquals(4, adder.add(2, 2), "This should succeed!")
+  }
+}


### PR DESCRIPTION
No behavioral changes, just extensions of the current test harness for AGP 3.6.x.