### PR TITLE
Allow turning off the auto-check for instrumentation lib integrity

### DIFF
--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Dsl.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Dsl.kt
@@ -455,19 +455,35 @@ class InstrumentationTestOptions {
   }
 
   /**
-   * Whether or not to enable support for JUnit 5 instrumentation tests
+   * Whether or not to check if the instrumentation tests
+   * are correctly set up. If this is disabled, the plugin
+   * won't raise an error during evaluation if the instrumentation
+   * libraries or the test runner are missing.
    */
+  var integrityCheckEnabled = true
+
+  /**
+   * Whether or not to check if the instrumentation tests
+   * are correctly set up. If this is disabled, the plugin
+   * won't raise an error during evaluation if the instrumentation
+   * libraries or the test runner are missing.
+   */
+  fun integrityCheckEnabled(state: Boolean) {
+    this.integrityCheckEnabled = state
+  }
+
+  @Deprecated(message = "This does not do anything anymore and can be safely removed")
   var enabled: Boolean = true
 
+  @Deprecated(message = "This does not do anything anymore and can be safely removed")
   fun enabled(state: Boolean) {
     this.enabled = state
   }
 
-  /**
-   * The version of the instrumentation companion library to use
-   */
+  @Deprecated(message = "This does not do anything anymore and can be safely removed")
   var version: String? = null
 
+  @Deprecated(message = "This does not do anything anymore and can be safely removed")
   fun version(version: String?) {
     this.version = version
   }

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Plugin.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Plugin.kt
@@ -81,8 +81,10 @@ class AndroidJUnitPlatformPlugin : Plugin<Project> {
   }
 
   private fun Project.configureInstrumentationTests() {
-    // Validate configuration of instrumentation tests.
-    // Both of the following statements must be fulfilled for this to work:
+    // Validate configuration of instrumentation tests, unless this
+    // step is deactivated through the DSL.
+    //
+    // Normally, both of the following statements must be fulfilled for this to work:
     // 1) A special test instrumentation runner argument is applied
     // 2) The test runner library is added
     val hasRunnerBuilder = android.defaultConfig
@@ -95,7 +97,10 @@ class AndroidJUnitPlatformPlugin : Plugin<Project> {
         .dependencies
         .any { it.group == INSTRUMENTATION_RUNNER_LIBRARY_GROUP && it.name == INSTRUMENTATION_RUNNER_LIBRARY_ARTIFACT }
 
-    if (hasRunnerBuilder xor hasDependency) {
+    val extension = project.android.testOptions.junitPlatform
+    val checkEnabled = extension.instrumentationTests.integrityCheckEnabled
+
+    if (checkEnabled && hasRunnerBuilder xor hasDependency) {
       val missingStep = if (hasRunnerBuilder) {
         "Add the android-test-runner library to the androidTestRuntimeOnly configuration's dependencies"
       } else {

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/PluginSpec.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/PluginSpec.kt
@@ -90,6 +90,11 @@ class PluginSpec : Spek({
             { assertThat(expected.cause!!.message).contains("Add the android-test-runner library") }
         )
       }
+
+      it("does actually work when the check is explicitly disabled") {
+        project.android.testOptions.junitPlatform.instrumentationTests.integrityCheckEnabled = false
+        project.evaluate()
+      }
     }
 
     on("configuring instrumentation test support only partially (2)") {
@@ -106,6 +111,11 @@ class PluginSpec : Spek({
             { assertThat(expected.cause!!.message).contains("Incomplete configuration for JUnit 5 instrumentation tests") },
             { assertThat(expected.cause!!.message).contains("Add the JUnit 5 RunnerBuilder") }
         )
+      }
+
+      it("does actually work when the check is explicitly disabled") {
+        project.android.testOptions.junitPlatform.instrumentationTests.integrityCheckEnabled = false
+        project.evaluate()
       }
     }
   }


### PR DESCRIPTION
A new DSL can disable this check, which would otherwise raise an
error if the instrumentation libs were missing, or the runner wasn't set
properly. This helps for advanced users who do their own dependency mgmt,
or even extend from the RunnerBuilder provided by android-junit5!