### PR TITLE
JUnit 5.5.1 & Better Compat implementation for class directories

### DIFF
--- a/buildSrc/src/main/kotlin/Artifacts.kt
+++ b/buildSrc/src/main/kotlin/Artifacts.kt
@@ -35,7 +35,7 @@ object Artifacts {
       platform = Java,
       groupId = "de.mannodermaus.gradle.plugins",
       artifactId = "android-junit5",
-      currentVersion = "1.5.0.1-SNAPSHOT",
+      currentVersion = "1.5.1.0-SNAPSHOT",
       latestStableVersion = "1.5.0.0",
       license = license,
       description = "Unit Testing with JUnit 5 for Android."

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -20,7 +20,7 @@ object Versions {
   const val com_android_tools_build_gradle_34x: String = "3.4.2"
   const val com_android_tools_build_gradle_35x: String = "3.5.0-rc01"
   const val com_android_tools_build_gradle_36x: String = "3.6.0-alpha05"
-  const val com_android_tools_build_gradle: String = "3.6.0-alpha05"
+  const val com_android_tools_build_gradle: String = "3.4.2"
 
   const val lint_gradle: String = "26.2.1"
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -7,84 +7,84 @@ import kotlin.String
  *
  * YOU are responsible for updating manually the dependency version. */
 object Versions {
-    const val espresso_core: String = "3.2.0"
+  const val espresso_core: String = "3.2.0"
 
-    const val androidx_test_core: String = "1.2.0"
-    const val androidx_test_monitor: String = "1.2.0"
-    const val androidx_test_runner: String = "1.2.0"
+  const val androidx_test_core: String = "1.2.0"
+  const val androidx_test_monitor: String = "1.2.0"
+  const val androidx_test_runner: String = "1.2.0"
 
-    const val aapt2: String = "3.2.1-4818971" 
+  const val aapt2: String = "3.2.1-4818971"
 
-    const val com_android_tools_build_gradle: String = "3.4.1"
-    const val com_android_tools_build_gradle_32x: String = "3.2.1"
-    const val com_android_tools_build_gradle_33x: String = "3.3.2"
-    const val com_android_tools_build_gradle_34x: String = "3.4.1"
-    const val com_android_tools_build_gradle_35x: String = "3.5.0-beta05"
-    const val com_android_tools_build_gradle_36x: String = "3.6.0-alpha04"
+  const val com_android_tools_build_gradle_32x: String = "3.2.1"
+  const val com_android_tools_build_gradle_33x: String = "3.3.2"
+  const val com_android_tools_build_gradle_34x: String = "3.4.2"
+  const val com_android_tools_build_gradle_35x: String = "3.5.0-rc01"
+  const val com_android_tools_build_gradle_36x: String = "3.6.0-alpha05"
+  const val com_android_tools_build_gradle: String = "3.6.0-alpha05"
 
-    const val lint_gradle: String = "26.2.1" 
+  const val lint_gradle: String = "26.2.1"
 
-    const val stream: String = "1.2.1" 
+  const val stream: String = "1.2.1"
 
-    const val gradle_versions_plugin: String = "0.20.0" 
+  const val gradle_versions_plugin: String = "0.20.0"
 
-    const val android_maven_gradle_plugin: String = "2.1"
+  const val android_maven_gradle_plugin: String = "2.1"
 
-    const val dokka: String = "0.9.18"
+  const val dokka: String = "0.9.18"
 
-    const val java_semver: String = "0.9.0" 
+  const val java_semver: String = "0.9.0"
 
-    const val gradle_bintray_plugin: String = "1.8.4" 
+  const val gradle_bintray_plugin: String = "1.8.4"
 
-    const val truth: String = "0.43"
+  const val truth: String = "0.43"
 
-    const val truth_android: String = "1.1.0"
+  const val truth_android: String = "1.1.0"
 
-    const val commons_io: String = "2.6" 
+  const val commons_io: String = "2.6"
 
-    const val commons_lang: String = "2.6" 
+  const val commons_lang: String = "2.6"
 
-    const val de_fayard_buildsrcversions_gradle_plugin: String = "0.3.2" 
+  const val de_fayard_buildsrcversions_gradle_plugin: String = "0.3.2"
 
-    const val android_junit5: String = "1.3.2.0-SNAPSHOT" 
+  const val android_junit5: String = "1.3.2.0-SNAPSHOT"
 
-    const val de_mannodermaus_junit5: String = "0.2.2" 
+  const val de_mannodermaus_junit5: String = "0.2.2"
 
-    const val android_maven_publish: String = "3.6.2" 
+  const val android_maven_publish: String = "3.6.2"
 
-    const val junit: String = "4.12" 
+  const val junit: String = "4.12"
 
-    const val assertj_core: String = "3.11.1" 
+  const val assertj_core: String = "3.11.1"
 
-    const val org_jetbrains_kotlin: String = "1.3.21"
+  const val org_jetbrains_kotlin: String = "1.3.21"
 
-    const val org_jetbrains_spek: String = "1.2.1"
+  const val org_jetbrains_spek: String = "1.2.1"
 
-    const val org_jacoco_agent: String = "0.8.2"
-    const val org_jacoco_ant: String = "0.8.2"
+  const val org_jacoco_agent: String = "0.8.2"
+  const val org_jacoco_ant: String = "0.8.2"
 
-    const val junit_pioneer: String = "0.2.2" // available: "0.3.0"
+  const val junit_pioneer: String = "0.2.2" // available: "0.3.0"
 
-    const val org_junit_jupiter: String = "5.5.0"
+  const val org_junit_jupiter: String = "5.5.1"
 
-    const val org_junit_platform: String = "1.5.0"
+  const val org_junit_platform: String = "1.5.1"
 
-    const val junit_vintage_engine: String = "5.5.0"
+  const val junit_vintage_engine: String = "5.5.1"
 
-    const val mockito_core: String = "2.19.0" // available: "2.23.4"
+  const val mockito_core: String = "2.19.0" // available: "2.23.4"
 
-    /**
-     *
-     *   To update Gradle, edit the wrapper file at path:
-     *      ./gradle/wrapper/gradle-wrapper.properties
-     */
-    object Gradle {
-        const val runningVersion: String = "5.0"
+  /**
+   *
+   *   To update Gradle, edit the wrapper file at path:
+   *      ./gradle/wrapper/gradle-wrapper.properties
+   */
+  object Gradle {
+    const val runningVersion: String = "5.0"
 
-        const val currentVersion: String = "5.0"
+    const val currentVersion: String = "5.0"
 
-        const val nightlyVersion: String = "5.2-20181230000028+0000"
+    const val nightlyVersion: String = "5.2-20181230000028+0000"
 
-        const val releaseCandidate: String = "5.1-rc-3"
-    }
+    const val releaseCandidate: String = "5.1-rc-3"
+  }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/android-junit5/src/main/groovy/de/mannodermaus/gradle/plugins/junit5/GroovyInterop.groovy
+++ b/plugin/android-junit5/src/main/groovy/de/mannodermaus/gradle/plugins/junit5/GroovyInterop.groovy
@@ -2,8 +2,6 @@ package de.mannodermaus.gradle.plugins.junit5
 
 import com.android.annotations.NonNull
 import com.android.build.gradle.api.BaseVariant
-import com.android.build.gradle.internal.scope.InternalArtifactType
-import com.android.build.gradle.internal.scope.VariantScope
 import com.android.build.gradle.internal.variant.BaseVariantData
 import com.android.builder.core.VariantTypeImpl
 import org.gradle.api.Project
@@ -33,19 +31,18 @@ class GroovyInterop {
   }
 
   /**
-   * Obtains the Java artifact files of the provided VariantScope in a safe manner.
+   * Obtains the Java class directory for the provided variant in a safe manner.
    *
-   * @because Some scopes, especially for Jacoco, don't have the files at hand through this API
-   * @param variant VariantScope to retrieve the Java artifact files from
+   * @because Recent versions of the Android Gradle Plugin have moved to a Provider-based architecture, deprecating the old direct accessors for tasks.
+   * @param variant Variant to retrieve the destination directory for class files from
    * @return That file
    */
   @NonNull
-  static Set<File> variantScope_getJavacArtifactFiles(VariantScope scope) {
-    if (scope.artifacts.hasArtifact(InternalArtifactType.JAVAC)) {
-      return scope.artifacts.getArtifactFiles(InternalArtifactType.JAVAC).files
+  static File baseVariant_javaCompileDestinationDir(BaseVariant variant) {
+    if (variant.hasProperty("javaCompileProvider")) {
+      return variant.javaCompileProvider.get().destinationDir
     } else {
-      return [new File(scope.globalScope.intermediatesDir,
-            "/classes/" + scope.variantConfiguration.dirName)]
+      return variant.javaCompile.destinationDir
     }
   }
 

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Interop.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Interop.kt
@@ -1,7 +1,6 @@
 package de.mannodermaus.gradle.plugins.junit5
 
 import com.android.build.gradle.api.BaseVariant
-import com.android.build.gradle.internal.scope.VariantScope
 import com.android.build.gradle.internal.variant.BaseVariantData
 import org.gradle.api.Project
 import org.gradle.testing.jacoco.tasks.JacocoReportBase
@@ -17,8 +16,8 @@ import java.io.File
 val BaseVariant.variantData: BaseVariantData
   get() = GroovyInterop.baseVariant_variantData(this)
 
-val VariantScope.safeJavacArtifactFiles: Set<File>
-  get() = GroovyInterop.variantScope_getJavacArtifactFiles(this)
+val BaseVariant.safeJavaCompileDestinationDir: File
+get() = GroovyInterop.baseVariant_javaCompileDestinationDir(this)
 
 /*
  * Compatibility methods for multiple Gradle versions.

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/providers/Java.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/providers/Java.kt
@@ -2,8 +2,7 @@ package de.mannodermaus.gradle.plugins.junit5.providers
 
 import com.android.build.gradle.api.BaseVariant
 import de.mannodermaus.gradle.plugins.junit5.internal.unitTestVariant
-import de.mannodermaus.gradle.plugins.junit5.safeJavacArtifactFiles
-import de.mannodermaus.gradle.plugins.junit5.variantData
+import de.mannodermaus.gradle.plugins.junit5.safeJavaCompileDestinationDir
 
 /**
  * Default Provider implementation for Java-based test root directories.
@@ -25,5 +24,5 @@ class JavaDirectoryProvider(private val variant: BaseVariant) : DirectoryProvide
           .toSet()
 
   private fun classFoldersOf(variant: BaseVariant) =
-      variant.variantData.scope.safeJavacArtifactFiles
+      setOf(variant.safeJavaCompileDestinationDir)
 }

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/PluginSpec.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/PluginSpec.kt
@@ -387,7 +387,8 @@ class PluginSpec : Spek({
               // TODO Clean this mess up once the Android Gradle Plugin 3.2.0 finally decides on something. :|
               listOf(
                   "build/intermediates/javac/debug/compileDebugJavaWithJavac/classes",
-                  "build/intermediates/classes/debug").forEach { folder ->
+                  "build/intermediates/classes/debug",
+                  "build/intermediates/javac/debug/classes").forEach { folder ->
                 project.file(folder).mkdirs()
                 project.file("$folder/R.class").createNewFile()
                 project.file("$folder/FirstFile.class").createNewFile()
@@ -396,7 +397,8 @@ class PluginSpec : Spek({
 
               listOf(
                   "build/intermediates/javac/release/compileReleaseJavaWithJavac/classes",
-                  "build/intermediates/classes/release").forEach { folder ->
+                  "build/intermediates/classes/release",
+                  "build/intermediates/javac/release/classes").forEach { folder ->
                 project.file(folder).mkdirs()
                 project.file("$folder/R.class").createNewFile()
                 project.file("$folder/SecondFile.class").createNewFile()

--- a/plugin/gradlew
+++ b/plugin/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/plugin/gradlew.bat
+++ b/plugin/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem      https://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Resolves #180. Turns out, we don't really need to reach into the internal `VariantScope` API to achieve what we want - `BaseVariant.javaCompile` (for old versions) and `BaseVariant.javaCompileProvider` do the job just fine.