### PR TITLE
Improve test reporting of parameterized instrumentation tests

### DIFF
--- a/instrumentation/core/build.gradle.kts
+++ b/instrumentation/core/build.gradle.kts
@@ -98,6 +98,7 @@ dependencies {
   runtimeOnly(Libs.junit_jupiter_engine)
 
   androidTestImplementation(Libs.junit_jupiter_api)
+  androidTestImplementation(Libs.junit_jupiter_params)
   androidTestImplementation(Libs.espresso_core)
 
   androidTestRuntimeOnly(project(":runner"))

--- a/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/JavaInstrumentationTests.java
+++ b/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/JavaInstrumentationTests.java
@@ -2,13 +2,37 @@ package de.mannodermaus.junit5;
 
 import androidx.test.core.app.ActivityScenario;
 
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DynamicContainer;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @SuppressWarnings("unused")
 class JavaInstrumentationTests {
@@ -36,7 +60,93 @@ class JavaInstrumentationTests {
     onView(withText("New Text")).check(matches(isDisplayed()));
   }
 
+  @Disabled
   @Test
-  void testAnotherThing() {
+  void testDisabled() {
+  }
+
+  @TestFactory
+  List<DynamicNode> testTemplate() {
+    return Arrays.asList(
+        DynamicContainer.dynamicContainer("Container 1",
+            Arrays.asList(
+                DynamicTest.dynamicTest("C1 Test1", () -> {
+
+                })
+            )
+        ),
+        DynamicTest.dynamicTest("Test 2", () -> {
+
+        })
+    );
+  }
+
+  @RepeatedTest(2)
+  void repeatedTest() {
+
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"ABC", "", "lol"})
+  void testParameterized(String parameter) {
+    assertNotNull(parameter);
+  }
+
+  private final List<String> fruits = Arrays.asList("apple", "banana");
+
+  @TestTemplate
+  @ExtendWith(CustomTestProvider.class)
+  void testTemplate(String fruit) {
+    if (!fruits.contains(fruit)) {
+      fail();
+    }
+  }
+
+  public static class CustomTestProvider implements TestTemplateInvocationContextProvider {
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+      return true;
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+      return Stream.of(invocationContext("apple"), invocationContext("banana"));
+    }
+
+    private TestTemplateInvocationContext invocationContext(String parameter) {
+      return new TestTemplateInvocationContext() {
+        @Override
+        public String getDisplayName(int invocationIndex) {
+          return "number " + invocationIndex + ": " + parameter;
+        }
+
+        @Override
+        public List<Extension> getAdditionalExtensions() {
+          return Collections.singletonList(new ParameterResolver() {
+            @Override
+            public boolean supportsParameter(ParameterContext parameterContext,
+                                             ExtensionContext extensionContext) {
+              return parameterContext.getParameter().getType().equals(String.class);
+            }
+
+            @Override
+            public Object resolveParameter(ParameterContext parameterContext,
+                                           ExtensionContext extensionContext) {
+              return parameter;
+            }
+          });
+        }
+      };
+    }
+  }
+
+  @Nested
+  class InnerTests {
+
+    @Test
+    void innerTest() {
+
+    }
   }
 }

--- a/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/KotlinInstrumentationTests.kt
+++ b/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/KotlinInstrumentationTests.kt
@@ -7,6 +7,8 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 class KotlinInstrumentationTests {
 
@@ -27,5 +29,11 @@ class KotlinInstrumentationTests {
     onView(withText("TestActivity")).check(matches(isDisplayed()))
     scenario.onActivity { it.changeText("New Text") }
     onView(withText("New Text")).check(matches(isDisplayed()))
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = [1, 4, 6, 7])
+  fun kotlinTestWithParameters(value: Int) {
+
   }
 }

--- a/instrumentation/runner/src/main/java/org/junit/platform/runner/AndroidJUnit5Utils.java
+++ b/instrumentation/runner/src/main/java/org/junit/platform/runner/AndroidJUnit5Utils.java
@@ -1,0 +1,36 @@
+package org.junit.platform.runner;
+
+import org.junit.platform.launcher.TestIdentifier;
+
+class AndroidJUnit5Utils {
+
+  private AndroidJUnit5Utils() {
+  }
+
+  /**
+   * Format a short ID out of the JUnit Jupiter unique identifier.
+   * This is used to detect a parameterized/dynamic test
+   *
+   * @param identifier Identifier to check
+   * @return The shortened ID of the identifier
+   */
+  private static String getShortId(TestIdentifier identifier) {
+    String id = identifier.getUniqueId();
+    int lastSlashIndex = id.lastIndexOf('/');
+    if (lastSlashIndex > -1 && id.length() >= lastSlashIndex) {
+      id = id.substring(lastSlashIndex + 1);
+    }
+    return id;
+  }
+
+  /**
+   * Check if the given TestIdentifier describes a "test template invocation",
+   * i.e. a dynamic test generated at runtime.
+   *
+   * @param identifier Identifier to check
+   * @return True if the TestIdentifier is a test template invocation, false otherwise
+   */
+  static boolean isTestTemplateInvocation(TestIdentifier identifier) {
+    return getShortId(identifier).startsWith("[test-template-invocation");
+  }
+}

--- a/instrumentation/runner/src/main/java/org/junit/platform/runner/AndroidJUnit5Utils.java
+++ b/instrumentation/runner/src/main/java/org/junit/platform/runner/AndroidJUnit5Utils.java
@@ -1,8 +1,22 @@
 package org.junit.platform.runner;
 
+import android.annotation.SuppressLint;
+
 import org.junit.platform.launcher.TestIdentifier;
 
+import java.util.Arrays;
+import java.util.List;
+
+@SuppressLint("NewApi")
 class AndroidJUnit5Utils {
+
+  private static final List<String> DYNAMIC_TEST_PREFIXES = Arrays.asList(
+      "[test-template-invocation",
+      "[dynamic-test",
+      "[dynamic-container",
+      "[test-factory",
+      "[test-template"
+  );
 
   private AndroidJUnit5Utils() {
   }
@@ -30,7 +44,8 @@ class AndroidJUnit5Utils {
    * @param identifier Identifier to check
    * @return True if the TestIdentifier is a test template invocation, false otherwise
    */
-  static boolean isTestTemplateInvocation(TestIdentifier identifier) {
-    return getShortId(identifier).startsWith("[test-template-invocation");
+  static boolean isDynamicTest(TestIdentifier identifier) {
+    String shortId = getShortId(identifier);
+    return DYNAMIC_TEST_PREFIXES.stream().anyMatch(shortId::startsWith);
   }
 }

--- a/instrumentation/runner/src/main/java/org/junit/platform/runner/AndroidJUnitPlatformRunnerListener.java
+++ b/instrumentation/runner/src/main/java/org/junit/platform/runner/AndroidJUnitPlatformRunnerListener.java
@@ -1,12 +1,74 @@
 package org.junit.platform.runner;
 
+import android.annotation.SuppressLint;
+
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.runner.Description;
+import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
+
+import static org.junit.platform.engine.TestExecutionResult.Status.ABORTED;
+import static org.junit.platform.engine.TestExecutionResult.Status.FAILED;
 
 /**
  * Required, public extension to allow access to package-private RunnerListener class
  */
-public final class AndroidJUnitPlatformRunnerListener extends JUnitPlatformRunnerListener {
-  public AndroidJUnitPlatformRunnerListener(JUnitPlatformTestTree testTree, RunNotifier notifier) {
-    super(testTree, notifier);
+@SuppressLint("NewApi")
+public final class AndroidJUnitPlatformRunnerListener implements TestExecutionListener {
+
+  private final AndroidJUnitPlatformTestTree testTree;
+  private final RunNotifier notifier;
+
+  public AndroidJUnitPlatformRunnerListener(AndroidJUnitPlatformTestTree testTree, RunNotifier notifier) {
+    this.testTree = testTree;
+    this.notifier = notifier;
+  }
+
+  @Override
+  public void executionStarted(TestIdentifier testIdentifier) {
+    Description description = testTree.getDescription(testIdentifier);
+
+    if (testIdentifier.isTest()) {
+      notifier.fireTestStarted(description);
+    }
+  }
+
+  @Override
+  public void dynamicTestRegistered(TestIdentifier testIdentifier) {
+    testTree.addDynamicDescription(testIdentifier, testIdentifier.getParentId().get());
+  }
+
+  @Override
+  public void executionSkipped(TestIdentifier testIdentifier, String reason) {
+    if (testIdentifier.isTest()) {
+      fireTestIgnored(testIdentifier);
+    } else {
+      testTree.getTestsInSubtree(testIdentifier).forEach(this::fireTestIgnored);
+    }
+  }
+
+  private void fireTestIgnored(TestIdentifier testIdentifier) {
+    Description description = testTree.getDescription(testIdentifier);
+    this.notifier.fireTestIgnored(description);
+  }
+
+  @Override
+  public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+    Description description = testTree.getDescription(testIdentifier);
+    TestExecutionResult.Status status = testExecutionResult.getStatus();
+    if (status == ABORTED) {
+      this.notifier.fireTestAssumptionFailed(toFailure(testExecutionResult, description));
+    } else if (status == FAILED) {
+      this.notifier.fireTestFailure(toFailure(testExecutionResult, description));
+    }
+    if (description.isTest()) {
+      this.notifier.fireTestFinished(description);
+    }
+  }
+
+  private Failure toFailure(TestExecutionResult testExecutionResult, Description description) {
+    return new Failure(description, testExecutionResult.getThrowable().orElse(null));
   }
 }

--- a/instrumentation/runner/src/main/java/org/junit/platform/runner/AndroidJUnitPlatformTestTree.java
+++ b/instrumentation/runner/src/main/java/org/junit/platform/runner/AndroidJUnitPlatformTestTree.java
@@ -1,18 +1,250 @@
 package org.junit.platform.runner;
 
+import android.annotation.SuppressLint;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.platform.commons.PreconditionViolationException;
+import org.junit.platform.commons.util.AnnotationUtils;
+import org.junit.platform.commons.util.StringUtils;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
+import org.junit.platform.suite.api.SuiteDisplayName;
+import org.junit.platform.suite.api.UseTechnicalNames;
 import org.junit.runner.Description;
+import org.junit.runner.manipulation.Filter;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.toSet;
+import static org.junit.platform.runner.AndroidJUnit5Utils.isTestTemplateInvocation;
 
 /**
- * Required, public extension to allow access to package-private TestTree class
+ * Required, public extension to allow access to package-private TestTree class.
+ * Furthermore, manipulate the test tree in a way that will fold {@link TestTemplate} cases
+ * into the test report, without having the Android instrumentation mess up their naming.
  */
-public final class AndroidJUnitPlatformTestTree extends JUnitPlatformTestTree {
+@SuppressLint("NewApi")
+public final class AndroidJUnitPlatformTestTree {
+
+  private final Map<TestIdentifier, Description> descriptions = new HashMap<>();
+  private final ModifiedTestPlan testPlan;
+  private final Function<TestIdentifier, String> nameExtractor;
+  private final Description suiteDescription;
+  private final Class<?> testClass;
+
   public AndroidJUnitPlatformTestTree(TestPlan testPlan, Class<?> testClass) {
-    super(testPlan, testClass);
+    this.testPlan = new ModifiedTestPlan(testPlan);
+    this.testClass = testClass;
+    this.nameExtractor = this::getTestName;
+    this.suiteDescription = generateSuiteDescription(testPlan, testClass);
   }
 
-  @Override
+  private String getTestName(TestIdentifier identifier) {
+    String baseName = useTechnicalNames(testClass) ? getTechnicalName(identifier) : identifier.getDisplayName();
+    if (isTestTemplateInvocation(identifier)) {
+      // Fold surrounding test template name into a distinct format
+      String reportName = identifier.getLegacyReportingName();
+
+      int bracketIndex = baseName.indexOf("] ");
+      if (bracketIndex > -1 && baseName.length() + 2 >= bracketIndex) {
+        baseName = baseName.substring(bracketIndex + 2);
+      }
+
+      return reportName + ": " + baseName;
+    }
+
+    return baseName;
+  }
+
+  public TestPlan getTestPlan() {
+    // Do not expose our custom TestPlan, because JUnit Platform wouldn't like that very much.
+    // Only internally, use the wrapped version
+    return testPlan.delegate;
+  }
+
+  private static boolean useTechnicalNames(Class<?> testClass) {
+    return testClass.isAnnotationPresent(UseTechnicalNames.class);
+  }
+
   public Description getSuiteDescription() {
-    return super.getSuiteDescription();
+    return this.suiteDescription;
+  }
+
+  Description getDescription(TestIdentifier identifier) {
+    return this.descriptions.get(identifier);
+  }
+
+  private Description generateSuiteDescription(TestPlan testPlan, Class<?> testClass) {
+    String displayName = useTechnicalNames(testClass) ? testClass.getName() : getSuiteDisplayName(testClass);
+    Description suiteDescription = Description.createSuiteDescription(displayName);
+    buildDescriptionTree(suiteDescription, testPlan);
+    return suiteDescription;
+  }
+
+  private String getSuiteDisplayName(Class<?> testClass) {
+    // @formatter:off
+    return AnnotationUtils.findAnnotation(testClass, SuiteDisplayName.class)
+        .map(SuiteDisplayName::value)
+        .filter(StringUtils::isNotBlank)
+        .orElse(testClass.getName());
+    // @formatter:on
+  }
+
+  private void buildDescriptionTree(Description suiteDescription, TestPlan testPlan) {
+    testPlan.getRoots().forEach(testIdentifier -> buildDescription(testIdentifier, suiteDescription, testPlan));
+  }
+
+  void addDynamicDescription(TestIdentifier newIdentifier, String parentId) {
+    Description parent = getDescription(this.testPlan.getTestIdentifier(parentId));
+    buildDescription(newIdentifier, parent, this.testPlan);
+  }
+
+  private void buildDescription(TestIdentifier identifier, Description parent, TestPlan testPlan) {
+    Description newDescription = createJUnit4Description(identifier, testPlan);
+    parent.addChild(newDescription);
+    this.descriptions.put(identifier, newDescription);
+    testPlan.getChildren(identifier).forEach(
+        testIdentifier -> buildDescription(testIdentifier, newDescription, testPlan));
+  }
+
+  private Description createJUnit4Description(TestIdentifier identifier, TestPlan testPlan) {
+    String name = nameExtractor.apply(identifier);
+    if (identifier.isTest()) {
+      String containerName = testPlan.getParent(identifier).map(nameExtractor).orElse("<unrooted>");
+      return Description.createTestDescription(containerName, name, identifier.getUniqueId());
+    }
+    return Description.createSuiteDescription(name, identifier.getUniqueId());
+  }
+
+  private String getTechnicalName(TestIdentifier testIdentifier) {
+    Optional<TestSource> optionalSource = testIdentifier.getSource();
+    if (optionalSource.isPresent()) {
+      TestSource source = optionalSource.get();
+      if (source instanceof ClassSource) {
+        return ((ClassSource) source).getJavaClass().getName();
+      } else if (source instanceof MethodSource) {
+        MethodSource methodSource = (MethodSource) source;
+        String methodParameterTypes = methodSource.getMethodParameterTypes();
+        if (StringUtils.isBlank(methodParameterTypes)) {
+          return methodSource.getMethodName();
+        }
+        return String.format("%s(%s)", methodSource.getMethodName(), methodParameterTypes);
+      }
+    }
+
+    // Else fall back to display name
+    return testIdentifier.getDisplayName();
+  }
+
+  Set<TestIdentifier> getTestsInSubtree(TestIdentifier ancestor) {
+    // @formatter:off
+    return testPlan.getDescendants(ancestor).stream()
+        .filter(TestIdentifier::isTest)
+        .collect(toCollection(LinkedHashSet::new));
+    // @formatter:on
+  }
+
+  Set<TestIdentifier> getFilteredLeaves(Filter filter) {
+    Set<TestIdentifier> identifiers = applyFilterToDescriptions(filter);
+    return removeNonLeafIdentifiers(identifiers);
+  }
+
+  private Set<TestIdentifier> removeNonLeafIdentifiers(Set<TestIdentifier> identifiers) {
+    return identifiers.stream().filter(isALeaf(identifiers)).collect(toSet());
+  }
+
+  private Predicate<? super TestIdentifier> isALeaf(Set<TestIdentifier> identifiers) {
+    return testIdentifier -> {
+      Set<TestIdentifier> descendants = testPlan.getDescendants(testIdentifier);
+      return identifiers.stream().noneMatch(descendants::contains);
+    };
+  }
+
+  private Set<TestIdentifier> applyFilterToDescriptions(Filter filter) {
+    // @formatter:off
+    return descriptions.entrySet()
+        .stream()
+        .filter(entry -> filter.shouldRun(entry.getValue()))
+        .map(Map.Entry::getKey)
+        .collect(toSet());
+    // @formatter:on
+  }
+
+  /**
+   * Custom drop-in TestPlan for Android purposes.
+   */
+  private static final class ModifiedTestPlan extends TestPlan {
+
+    private final TestPlan delegate;
+
+    ModifiedTestPlan(TestPlan delegate) {
+      super(delegate.containsTests());
+      this.delegate = delegate;
+    }
+
+    @Override
+    public Optional<TestIdentifier> getParent(TestIdentifier child) {
+      // Since parameterized tests are interpreted incorrectly by Android,
+      // they access their grandparent identifier, instead of the parent like usual.
+      // This causes each invocation to be grouped under the class, rather than next to it
+      // using a butchered container name.
+      if (isTestTemplateInvocation(child)) {
+        return delegate.getParent(child).flatMap(delegate::getParent);
+      }
+
+      return delegate.getParent(child);
+    }
+
+    /* Unchanged */
+
+    @Override
+    public void add(TestIdentifier testIdentifier) {
+      delegate.add(testIdentifier);
+    }
+
+    @Override
+    public Set<TestIdentifier> getRoots() {
+      return delegate.getRoots();
+    }
+
+    @Override
+    public Set<TestIdentifier> getChildren(TestIdentifier parent) {
+      return delegate.getChildren(parent);
+    }
+
+    @Override
+    public Set<TestIdentifier> getChildren(String parentId) {
+      return delegate.getChildren(parentId);
+    }
+
+    @Override
+    public TestIdentifier getTestIdentifier(String uniqueId) throws PreconditionViolationException {
+      return delegate.getTestIdentifier(uniqueId);
+    }
+
+    @Override
+    public long countTestIdentifiers(Predicate<? super TestIdentifier> predicate) {
+      return delegate.countTestIdentifiers(predicate);
+    }
+
+    @Override
+    public Set<TestIdentifier> getDescendants(TestIdentifier parent) {
+      return delegate.getDescendants(parent);
+    }
+
+    @Override
+    public boolean containsTests() {
+      return delegate.containsTests();
+    }
   }
 }


### PR DESCRIPTION
Manipulate how dynamic tests are formatted for the Android instrumentation in order to keep the reports clean and readable.

*Before:*
<img width="450" alt="Screen Shot 2019-11-15 at 21 16 50" src="https://user-images.githubusercontent.com/3897705/68972987-6288d680-07ed-11ea-8f35-1d8a4cba6683.png">

*After:*
<img width="450" alt="Screen Shot 2019-11-15 at 21 13 17" src="https://user-images.githubusercontent.com/3897705/68972992-6583c700-07ed-11ea-9b14-c914c83e767b.png">
