### PR TITLE
Replace usage of Scope API for variants

### DIFF
--- a/buildSrc/src/main/kotlin/Artifacts.kt
+++ b/buildSrc/src/main/kotlin/Artifacts.kt
@@ -35,7 +35,7 @@ object Artifacts {
       platform = Java,
       groupId = "de.mannodermaus.gradle.plugins",
       artifactId = "android-junit5",
-      currentVersion = "1.6.1.0-SNAPSHOT",
+      currentVersion = "1.6.0.1-SNAPSHOT",
       latestStableVersion = "1.6.0.0",
       license = license,
       description = "Unit Testing with JUnit 5 for Android."

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -40,6 +40,8 @@ object Libs {
         Versions.com_android_tools_build_gradle_36x
     const val com_android_tools_build_gradle_40x: String = "com.android.tools.build:gradle:" +
         Versions.com_android_tools_build_gradle_40x
+    const val com_android_tools_build_gradle_41x: String = "com.android.tools.build:gradle:" +
+        Versions.com_android_tools_build_gradle_41x
 
     /**
      * https://developer.android.com/studio */

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -18,6 +18,7 @@ object Versions {
   const val com_android_tools_build_gradle_35x: String = "3.5.0"
   const val com_android_tools_build_gradle_36x: String = "3.6.0"
   const val com_android_tools_build_gradle_40x: String = "4.0.0-beta01"
+  const val com_android_tools_build_gradle_41x: String = "4.1.0-alpha01"
   const val com_android_tools_build_gradle: String = com_android_tools_build_gradle_35x
 
   const val lint_gradle: String = "26.5.0"

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -4,7 +4,9 @@ Change Log
 ## Unreleased
 
 #### Added
+- Compatibility with Android Gradle Plugin 4.1.x
 #### Changed
+- Restricted visibility of internal APIs to prevent them from leaking into consumer code
 #### Fixed
 #### Removed
 

--- a/plugin/android-junit5/build.gradle.kts
+++ b/plugin/android-junit5/build.gradle.kts
@@ -50,6 +50,7 @@ gradlePlugin {
 // Use JUnit 5
 tasks.withType<Test> {
   useJUnitPlatform()
+  failFast = true
   testLogging {
     events = setOf(TestLogEvent.STARTED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
     exceptionFormat = TestExceptionFormat.FULL
@@ -67,6 +68,7 @@ tasks.named("processTestResources", Copy::class.java).configure {
       "AGP_35X" to Versions.com_android_tools_build_gradle_35x,
       "AGP_36X" to Versions.com_android_tools_build_gradle_36x,
       "AGP_40X" to Versions.com_android_tools_build_gradle_40x,
+      "AGP_41X" to Versions.com_android_tools_build_gradle_41x,
       "KOTLIN" to Versions.org_jetbrains_kotlin,
 
       "KOTLIN_STD_LIB" to Libs.kotlin_stdlib,
@@ -112,7 +114,8 @@ data class AgpConfiguration(val version: String, val dependency: String) {
 private val agpConfigurations = listOf(
     AgpConfiguration("3.5", Libs.com_android_tools_build_gradle_35x),
     AgpConfiguration("3.6", Libs.com_android_tools_build_gradle_36x),
-    AgpConfiguration("4.0", Libs.com_android_tools_build_gradle_40x)
+    AgpConfiguration("4.0", Libs.com_android_tools_build_gradle_40x),
+    AgpConfiguration("4.1", Libs.com_android_tools_build_gradle_41x)
 )
 
 configurations {

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Interop.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Interop.kt
@@ -1,7 +1,6 @@
 package de.mannodermaus.gradle.plugins.junit5
 
 import com.android.build.gradle.api.BaseVariant
-import com.android.build.gradle.internal.variant.BaseVariantData
 import de.mannodermaus.gradle.plugins.junit5.internal.invokeTyped
 import de.mannodermaus.gradle.plugins.junit5.internal.reflectiveMethod
 import org.gradle.api.Project
@@ -22,17 +21,6 @@ import java.io.File
  * BaseVariant
  * =====================================================================================================================
  */
-
-/**
- * Obtains the VariantData of the provided Variant.
- *
- * @because 'BaseVariant.variantData' is protected and can't be accessed through Kotlin directly
- * @return The variant data
- */
-val BaseVariant.variantData: BaseVariantData
-  get() = this.reflectiveMethod("getVariantData")
-      ?.invokeTyped<BaseVariantData>(this)
-      ?: throw IllegalArgumentException("BaseVariant.variantData not available")
 
 /**
  * Obtains the Java class directory for the provided variant in a safe manner.

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/ConfigurationKind.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/ConfigurationKind.kt
@@ -1,6 +1,6 @@
 package de.mannodermaus.gradle.plugins.junit5.internal
 
-enum class ConfigurationKind(internal val value: String) {
+internal enum class ConfigurationKind(internal val value: String) {
   APP(""),
   TEST("test"),
   ANDROID_TEST("androidTest")

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/ConfigurationScope.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/ConfigurationScope.kt
@@ -1,6 +1,6 @@
 package de.mannodermaus.gradle.plugins.junit5.internal
 
-enum class ConfigurationScope(internal vararg val values: String) {
+internal enum class ConfigurationScope(internal vararg val values: String) {
   API("api", "compile"),
   IMPLEMENTATION("implementation", "compile"),
   COMPILE_ONLY("compileOnly", "provided"),

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/Extensions.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/Extensions.kt
@@ -202,11 +202,33 @@ val BaseVariant.instrumentationTestVariant: TestVariant?
   }
 
 /**
+ * Composes the name of the variant-specific Gradle task with the given [prefix] and [suffix].
+ * For example, to obtain the "free" variant's assemble task name, call `variant.getTaskName(prefix = "assemble")`.
+ */
+internal fun BaseVariant.getTaskName(prefix: String = "", suffix: String = ""): String {
+  // At least one value must be provided
+  require(prefix.isNotEmpty() || suffix.isNotEmpty())
+
+  return StringBuilder().apply {
+    append(prefix)
+    append(if (isEmpty()) {
+      name
+    } else {
+      name.capitalize()
+    })
+    append(suffix.capitalize())
+  }.toString()
+}
+
+/**
  * Obtains the {AndroidUnitTest} for the provided variant.
  */
-fun TaskContainer.testTaskOf(variant: BaseVariant): AndroidUnitTest {
-  val taskName = variant.variantData.scope.getTaskName(VariantTypeCompat.UNIT_TEST_PREFIX,
-      VariantTypeCompat.UNIT_TEST_SUFFIX)
+internal fun TaskContainer.testTaskOf(variant: BaseVariant): AndroidUnitTest {
+  // From AGP 4.1 onwards, there is no Scope API on VariantData anymore.
+  // Task names must be constructed manually
+  val taskName = variant.getTaskName(
+      prefix = VariantTypeCompat.UNIT_TEST_PREFIX,
+      suffix = VariantTypeCompat.UNIT_TEST_SUFFIX)
   return getByName(taskName) as AndroidUnitTest
 }
 

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/Reflective.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/Reflective.kt
@@ -13,7 +13,7 @@ import java.lang.reflect.Method
  * @param paramTypes Parameter types of the method's signature
  * @return A reference to the method with that signature, or null if it doesn't exist
  */
-fun Any.reflectiveMethod(named: String, vararg paramTypes: Class<*>): Method? =
+internal fun Any.reflectiveMethod(named: String, vararg paramTypes: Class<*>): Method? =
     try {
       val targetClass = if (this is Class<*>) {
         this
@@ -34,6 +34,6 @@ fun Any.reflectiveMethod(named: String, vararg paramTypes: Class<*>): Method? =
  * @param params Parameters to call the method with
  * @return Result, cast to the desired type
  */
-fun <T> Method.invokeTyped(target: Any? = null, vararg params: Any?): T? {
+internal fun <T> Method.invokeTyped(target: Any? = null, vararg params: Any?): T? {
   return this.invoke(target, *params) as? T?
 }

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/AndroidJUnit5JacocoReport.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/AndroidJUnit5JacocoReport.kt
@@ -2,10 +2,7 @@ package de.mannodermaus.gradle.plugins.junit5.tasks
 
 import com.android.build.gradle.api.BaseVariant
 import de.mannodermaus.gradle.plugins.junit5.*
-import de.mannodermaus.gradle.plugins.junit5.internal.android
-import de.mannodermaus.gradle.plugins.junit5.internal.extensionByName
-import de.mannodermaus.gradle.plugins.junit5.internal.junit5Info
-import de.mannodermaus.gradle.plugins.junit5.internal.maybeCreate
+import de.mannodermaus.gradle.plugins.junit5.internal.*
 import de.mannodermaus.gradle.plugins.junit5.providers.DirectoryProvider
 import de.mannodermaus.gradle.plugins.junit5.providers.mainClassDirectories
 import de.mannodermaus.gradle.plugins.junit5.providers.mainSourceDirectories
@@ -54,9 +51,7 @@ open class AndroidJUnit5JacocoReport : JacocoReport() {
       private val directoryProviders: Collection<DirectoryProvider>
   ) {
 
-    private val scope = variant.variantData.scope
-
-    val name: String = scope.getTaskName(TASK_NAME_DEFAULT)
+    val name: String = variant.getTaskName(prefix = TASK_NAME_DEFAULT)
 
     val type = AndroidJUnit5JacocoReport::class.java
 

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/AndroidJUnit5WriteFilters.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/AndroidJUnit5WriteFilters.kt
@@ -2,8 +2,8 @@ package de.mannodermaus.gradle.plugins.junit5.tasks
 
 import com.android.build.gradle.api.TestVariant
 import de.mannodermaus.gradle.plugins.junit5.INSTRUMENTATION_FILTER_RES_FILE_NAME
+import de.mannodermaus.gradle.plugins.junit5.internal.getTaskName
 import de.mannodermaus.gradle.plugins.junit5.internal.junit5ConfigurationOf
-import de.mannodermaus.gradle.plugins.junit5.variantData
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.CacheableTask
@@ -80,9 +80,7 @@ open class AndroidJUnit5WriteFilters : DefaultTask() {
       private val instrumentationTestVariant: TestVariant
   ) {
 
-    private val scope = instrumentationTestVariant.variantData.scope
-
-    val name: String = scope.getTaskName(TASK_NAME_DEFAULT)
+    val name: String = instrumentationTestVariant.getTaskName(prefix = TASK_NAME_DEFAULT)
 
     val type = AndroidJUnit5WriteFilters::class.java
 

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/FunctionalTests.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/FunctionalTests.kt
@@ -1,5 +1,6 @@
 package de.mannodermaus.gradle.plugins.junit5
 
+import de.mannodermaus.gradle.plugins.junit5.annotations.DisabledOnCI
 import de.mannodermaus.gradle.plugins.junit5.util.AgpVersion
 import de.mannodermaus.gradle.plugins.junit5.util.assertThat
 import de.mannodermaus.gradle.plugins.junit5.util.withPrunedPluginClasspath
@@ -14,9 +15,13 @@ class FunctionalTests {
 
   // Iterate over all values in the AgpVersion enum and,
   // using the project with that name located in the test resource folder,
-  // run a basic integration test with the JUnit 5 plugin
+  // run a basic integration test with the JUnit 5 plugin.
+  //
+  // The CI server does not have enough memory to run multiple nested virtual Gradle builds.
+  // Restrict execution of this test method to the local machine only
   @DisplayName("Integration Tests with Android Gradle Plugin")
   @TestFactory
+  @DisabledOnCI
   fun agpIntegrationTests(): List<DynamicTest> =
       AgpVersion.values()
           .map { agpVersion ->
@@ -38,46 +43,11 @@ class FunctionalTests {
               // Assert outputs;
               assertThat(result).task(":test").hasOutcome(TaskOutcome.SUCCESS)
 
-              // based on the project setup, assert different things.
-              // The assignment to the variable is unused, but required in order to enforce
-              // a case for each version
               with(result) {
-                @Suppress("UNUSED_VARIABLE")
-                val u: Any = when (agpVersion) {
-                  // ------------------------------------------------------------------------------------------------
-                  // AGP 3.5
-                  // - Product Flavors
-                  // - Build Types
-                  // ------------------------------------------------------------------------------------------------
-                  AgpVersion.AGP_35X -> {
-                    assertAgpTests(buildType = "debug", productFlavor = "free", tests = listOf("JavaTest"))
-                    assertAgpTests(buildType = "debug", productFlavor = "paid", tests = listOf("JavaTest", "KotlinPaidDebugTest"))
-                    assertAgpTests(buildType = "release", productFlavor = "free", tests = listOf("JavaTest", "KotlinReleaseTest", "JavaFreeReleaseTest"))
-                    assertAgpTests(buildType = "release", productFlavor = "paid", tests = listOf("JavaTest", "KotlinReleaseTest"))
-                  }
-                  // ------------------------------------------------------------------------------------------------
-                  // AGP 3.6
-                  // - Product Flavors
-                  // - Build Types
-                  // ------------------------------------------------------------------------------------------------
-                  AgpVersion.AGP_36X -> {
-                    assertAgpTests(buildType = "debug", productFlavor = "free", tests = listOf("JavaTest"))
-                    assertAgpTests(buildType = "debug", productFlavor = "paid", tests = listOf("JavaTest", "KotlinPaidDebugTest"))
-                    assertAgpTests(buildType = "release", productFlavor = "free", tests = listOf("JavaTest", "KotlinReleaseTest", "JavaFreeReleaseTest"))
-                    assertAgpTests(buildType = "release", productFlavor = "paid", tests = listOf("JavaTest", "KotlinReleaseTest"))
-                  }
-                  // ------------------------------------------------------------------------------------------------
-                  // AGP 4.0
-                  // - Product Flavors
-                  // - Build Types
-                  // ------------------------------------------------------------------------------------------------
-                  AgpVersion.AGP_40X -> {
-                    assertAgpTests(buildType = "debug", productFlavor = "free", tests = listOf("JavaTest"))
-                    assertAgpTests(buildType = "debug", productFlavor = "paid", tests = listOf("JavaTest", "KotlinPaidDebugTest"))
-                    assertAgpTests(buildType = "release", productFlavor = "free", tests = listOf("JavaTest", "KotlinReleaseTest", "JavaFreeReleaseTest"))
-                    assertAgpTests(buildType = "release", productFlavor = "paid", tests = listOf("JavaTest", "KotlinReleaseTest"))
-                  }
-                }
+                assertAgpTests(buildType = "debug", productFlavor = "free", tests = listOf("JavaTest"))
+                assertAgpTests(buildType = "debug", productFlavor = "paid", tests = listOf("JavaTest", "KotlinPaidDebugTest"))
+                assertAgpTests(buildType = "release", productFlavor = "free", tests = listOf("JavaTest", "KotlinReleaseTest", "JavaFreeReleaseTest"))
+                assertAgpTests(buildType = "release", productFlavor = "paid", tests = listOf("JavaTest", "KotlinReleaseTest"))
               }
             }
           }

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/annotations/DisabledOnCI.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/annotations/DisabledOnCI.kt
@@ -1,2 +1,6 @@
 package de.mannodermaus.gradle.plugins.junit5.annotations
 
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
+
+@DisabledIfEnvironmentVariable(named = "CI", matches = "true")
+annotation class DisabledOnCI

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/annotations/DisabledOnCI.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/annotations/DisabledOnCI.kt
@@ -1,0 +1,2 @@
+package de.mannodermaus.gradle.plugins.junit5.annotations
+

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/AgpVersion.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/AgpVersion.kt
@@ -5,7 +5,8 @@ enum class AgpVersion(val fileKey: String,
 
   AGP_35X("agp35x"),
   AGP_36X("agp36x"),
-  AGP_40X("agp40x");
+  AGP_40X("agp40x"),
+  AGP_41X("agp41x", requiresGradle = "6.2");
 
   // Create a pretty string from the fileKey property.
   // Example:

--- a/plugin/android-junit5/src/test/projects/agp41x/build.gradle
+++ b/plugin/android-junit5/src/test/projects/agp41x/build.gradle
@@ -1,0 +1,47 @@
+buildscript {
+  repositories {
+    google()
+    jcenter()
+  }
+}
+
+plugins {
+  id "com.android.application"
+  id "org.jetbrains.kotlin.android"
+  id "de.mannodermaus.android-junit5"
+  id "jacoco"
+}
+
+def version = com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION
+if (version != AGP_41X) {
+  throw new IllegalStateException("Incorrect AGP version. Expected $AGP_41X, got $version")
+}
+
+repositories {
+  google()
+  jcenter()
+}
+
+android {
+  compileSdkVersion COMPILE_SDK_VERSION
+
+  flavorDimensions "environment"
+  productFlavors {
+    free {
+      dimension "environment"
+    }
+    paid {
+      dimension "environment"
+    }
+  }
+
+  testOptions.unitTests.all {
+    testLogging.events = ["passed", "skipped", "failed"]
+  }
+}
+
+dependencies {
+  implementation KOTLIN_STD_LIB
+  testImplementation JUPITER_API
+  testRuntimeOnly JUPITER_ENGINE
+}

--- a/plugin/android-junit5/src/test/projects/agp41x/settings.gradle
+++ b/plugin/android-junit5/src/test/projects/agp41x/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+  repositories {
+    google()
+  }
+  resolutionStrategy {
+    eachPlugin {
+      if (requested.id.id == "com.android.application") {
+        useModule("com.android.tools.build:gradle:$AGP_41X")
+      }
+      if (requested.id.id == "org.jetbrains.kotlin.android") {
+        useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN")
+      }
+    }
+  }
+}

--- a/plugin/android-junit5/src/test/projects/agp41x/src/main/AndroidManifest.xml
+++ b/plugin/android-junit5/src/test/projects/agp41x/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="de.mannodermaus.app"></manifest>

--- a/plugin/android-junit5/src/test/projects/agp41x/src/main/java/de/mannodermaus/app/Adder.java
+++ b/plugin/android-junit5/src/test/projects/agp41x/src/main/java/de/mannodermaus/app/Adder.java
@@ -1,0 +1,7 @@
+package de.mannodermaus.app;
+
+public class Adder {
+  public int add(int a, int b) {
+    return a + b;
+  }
+}

--- a/plugin/android-junit5/src/test/projects/agp41x/src/test/java/de/mannodermaus/app/JavaTest.java
+++ b/plugin/android-junit5/src/test/projects/agp41x/src/test/java/de/mannodermaus/app/JavaTest.java
@@ -1,0 +1,13 @@
+package de.mannodermaus.app;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class JavaTest {
+  @Test
+  void test() {
+    Adder adder = new Adder();
+    assertEquals(4, adder.add(2, 2), "This should succeed!");
+  }
+}

--- a/plugin/android-junit5/src/test/projects/agp41x/src/testFreeRelease/java/de/mannodermaus/app/JavaFreeReleaseTest.java
+++ b/plugin/android-junit5/src/test/projects/agp41x/src/testFreeRelease/java/de/mannodermaus/app/JavaFreeReleaseTest.java
@@ -1,0 +1,13 @@
+package de.mannodermaus.app;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class JavaFreeReleaseTest {
+  @Test
+  void test() {
+    Adder adder = new Adder();
+    assertEquals(4, adder.add(2, 2), "This should succeed!");
+  }
+}

--- a/plugin/android-junit5/src/test/projects/agp41x/src/testPaidDebug/java/de/mannodermaus/app/KotlinPaidDebugTest.kt
+++ b/plugin/android-junit5/src/test/projects/agp41x/src/testPaidDebug/java/de/mannodermaus/app/KotlinPaidDebugTest.kt
@@ -1,0 +1,12 @@
+package de.mannodermaus.app
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class KotlinPaidDebugTest {
+  @Test
+  fun test() {
+    val adder = Adder()
+    assertEquals(4, adder.add(2, 2), "This should succeed!")
+  }
+}

--- a/plugin/android-junit5/src/test/projects/agp41x/src/testRelease/java/de/mannodermaus/app/KotlinReleaseTest.kt
+++ b/plugin/android-junit5/src/test/projects/agp41x/src/testRelease/java/de/mannodermaus/app/KotlinReleaseTest.kt
@@ -1,0 +1,12 @@
+package de.mannodermaus.app
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class KotlinReleaseTest {
+  @Test
+  fun test() {
+    val adder = Adder()
+    assertEquals(4, adder.add(2, 2), "This should succeed!")
+  }
+}


### PR DESCRIPTION
This brings compatibility with Android Gradle Plugin 4.1, which removes the `VariantScope` accessors. These were only used to format task names and it's safe to manually compose them, so this PR does exactly that. Older plugin versions are unaffected by this.

Furthermore, the visibility of the internal API methods has been reduced to prevent them from leaking into consumer code.

Resolves #208.