### PR TITLE
Introduce SemanticVersion checks for build script template processor / Update to JUnit 5.7.0

### DIFF
--- a/README.md.template
+++ b/README.md.template
@@ -14,6 +14,18 @@ Furthermore, this repository provides a small showcase of the functionality prov
 ## Download
 
 <details open>
+  <summary>Kotlin</summary>
+
+  ```kotlin
+  buildscript {
+    dependencies {
+      classpath("de.mannodermaus.gradle.plugins:android-junit5:${pluginVersion}")
+    }
+  }
+  ```
+</details>
+
+<details>
   <summary>Groovy</summary>
   
   ```groovy
@@ -25,48 +37,14 @@ Furthermore, this repository provides a small showcase of the functionality prov
   ```
 </details>
 
-<details>
-  <summary>Kotlin</summary>
-  
-  ```kotlin
-  buildscript {
-    dependencies {
-      classpath("de.mannodermaus.gradle.plugins:android-junit5:${pluginVersion}")
-    }
-  }
-  ```
-</details>
-
 <br/>
 
 Snapshots of the development version are available through [Sonatype's `snapshots` repository][sonatyperepo].
 
 ## Setup
-
 <details open>
-  <summary>Groovy</summary>
-
-  ```groovy
-  apply plugin: "de.mannodermaus.android-junit5"
-
-  dependencies {
-    // (Required) Writing and executing Unit Tests on the JUnit Platform
-    testImplementation "${Libs.junitJupiterApi}"
-    testRuntimeOnly "${Libs.junitJupiterEngine}"
-
-    // (Optional) If you need "Parameterized Tests"
-    testImplementation "${Libs.junitJupiterParams}"
-
-    // (Optional) If you also have JUnit 4-based tests
-    testImplementation "${Libs.junit4}"
-    testRuntimeOnly "${Libs.junitVintageEngine}"
-  }
-  ```
-</details>
-
-<details>
   <summary>Kotlin</summary>
-  
+
   ```kotlin
   plugins {
     id("de.mannodermaus.android-junit5")
@@ -83,6 +61,27 @@ Snapshots of the development version are available through [Sonatype's `snapshot
     // (Optional) If you also have JUnit 4-based tests
     testImplementation("${Libs.junit4}")
     testRuntimeOnly("${Libs.junitVintageEngine}")
+  }
+  ```
+</details>
+
+<details>
+  <summary>Groovy</summary>
+
+  ```groovy
+  apply plugin: "de.mannodermaus.android-junit5"
+
+  dependencies {
+    // (Required) Writing and executing Unit Tests on the JUnit Platform
+    testImplementation "${Libs.junitJupiterApi}"
+    testRuntimeOnly "${Libs.junitJupiterEngine}"
+
+    // (Optional) If you need "Parameterized Tests"
+    testImplementation "${Libs.junitJupiterParams}"
+
+    // (Optional) If you also have JUnit 4-based tests
+    testImplementation "${Libs.junit4}"
+    testRuntimeOnly "${Libs.junitVintageEngine}"
   }
   ```
 </details>
@@ -104,42 +103,6 @@ There is experimental support for Android instrumentation tests, which requires 
 To start writing instrumentation tests with JUnit Jupiter, make the following changes to your module's build script:
 
 <details open>
-  <summary>Groovy</summary>
-  
-  ```groovy
-  android {
-    defaultConfig {
-      // 1) Make sure to use the AndroidJUnitRunner, of a subclass of it. This requires a dependency on androidx.test:runner, too!
-      testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-      // 2) Connect JUnit 5 to the runner
-      testInstrumentationRunnerArgument "runnerBuilder", "de.mannodermaus.junit5.AndroidJUnit5Builder"
-    }
-
-    // 3) Java 8 is required
-    compileOptions {
-      sourceCompatibility JavaVersion.VERSION_1_8
-      targetCompatibility JavaVersion.VERSION_1_8
-    }
-    
-    // 4) JUnit 5 will bundle in files with identical paths; exclude them
-    packagingOptions {
-      exclude "META-INF/LICENSE*"
-    }
-  }
-
-  dependencies {
-    // 5) Jupiter API & Test Runner, if you don't have it already
-    androidTestImplementation "${Libs.androidxTestRunner}"
-    androidTestImplementation "${Libs.junitJupiterApi}"
-    
-    // 6) The instrumentation test companion libraries
-    androidTestImplementation "de.mannodermaus.junit5:android-test-core:${instrumentationVersion}"
-    androidTestRuntimeOnly "de.mannodermaus.junit5:android-test-runner:${instrumentationVersion}"
-  }
-  ```
-</details>
-
-<details>
   <summary>Kotlin</summary>
   
   ```groovy
@@ -170,6 +133,42 @@ To start writing instrumentation tests with JUnit Jupiter, make the following ch
     // 6) The instrumentation test companion libraries
     androidTestImplementation("de.mannodermaus.junit5:android-test-core:${instrumentationVersion}")
     androidTestRuntimeOnly("de.mannodermaus.junit5:android-test-runner:${instrumentationVersion}")
+  }
+  ```
+</details>
+
+<details>
+  <summary>Groovy</summary>
+
+  ```groovy
+  android {
+    defaultConfig {
+      // 1) Make sure to use the AndroidJUnitRunner, of a subclass of it. This requires a dependency on androidx.test:runner, too!
+      testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+      // 2) Connect JUnit 5 to the runner
+      testInstrumentationRunnerArgument "runnerBuilder", "de.mannodermaus.junit5.AndroidJUnit5Builder"
+    }
+
+    // 3) Java 8 is required
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_1_8
+      targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    // 4) JUnit 5 will bundle in files with identical paths; exclude them
+    packagingOptions {
+      exclude "META-INF/LICENSE*"
+    }
+  }
+
+  dependencies {
+    // 5) Jupiter API & Test Runner, if you don't have it already
+    androidTestImplementation "${Libs.androidxTestRunner}"
+    androidTestImplementation "${Libs.junitJupiterApi}"
+
+    // 6) The instrumentation test companion libraries
+    androidTestImplementation "de.mannodermaus.junit5:android-test-core:${instrumentationVersion}"
+    androidTestRuntimeOnly "de.mannodermaus.junit5:android-test-runner:${instrumentationVersion}"
   }
   ```
 </details>

--- a/buildSrc/src/main/kotlin/Artifacts.kt
+++ b/buildSrc/src/main/kotlin/Artifacts.kt
@@ -47,7 +47,7 @@ object Artifacts {
       platform = Java,
       groupId = "de.mannodermaus.gradle.plugins",
       artifactId = "android-junit5",
-      currentVersion = "1.6.2.1-SNAPSHOT",
+      currentVersion = "1.7.0.0-SNAPSHOT",
       latestStableVersion = "1.6.2.0",
       license = license,
       description = "Unit Testing with JUnit 5 for Android."

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -17,8 +17,8 @@ object Plugins {
   val android35x: Agp = Agp("com.android.tools.build:gradle:3.5.4")
   val android36x: Agp = Agp("com.android.tools.build:gradle:3.6.4")
   val android40x: Agp = Agp("com.android.tools.build:gradle:4.0.1")
-  val android41x: Agp = Agp("com.android.tools.build:gradle:4.1.0-rc02", requiresGradle = "6.5")
-  val android42x: Agp = Agp("com.android.tools.build:gradle:4.2.0-alpha10", requiresGradle = "6.5")
+  val android41x: Agp = Agp("com.android.tools.build:gradle:4.1.0-rc03", requiresGradle = "6.5")
+  val android42x: Agp = Agp("com.android.tools.build:gradle:4.2.0-alpha12", requiresGradle = "6.6.1")
   val android: Agp = android35x
 
   val supportedAndroidPlugins = listOf(
@@ -53,9 +53,9 @@ object Libs {
   const val konfToml: Lib = "com.uchuhimo:konf-toml:0.22.1"
 
   // JUnit 5
-  private const val junitJupiterVersion = "5.6.2"
-  private const val junitPlatformVersion = "1.6.2"
-  private const val junitVintageVersion = "5.6.2"
+  private const val junitJupiterVersion = "5.7.0"
+  private const val junitPlatformVersion = "1.7.0"
+  private const val junitVintageVersion = "5.7.0"
   const val junitJupiterApi: Lib = "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
   const val junitJupiterEngine: Lib = "org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion"
   const val junitJupiterParams: Lib = "org.junit.jupiter:junit-jupiter-params:$junitJupiterVersion"

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/projects/BuildScriptTemplateProcessor.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/projects/BuildScriptTemplateProcessor.kt
@@ -55,8 +55,8 @@ class BuildScriptTemplateProcessor(private val targetGradleVersion: String?,
         val ifgradleExpression = ifgradleMatch.groupValues.last()
 
         // When the given Gradle requirement is null, or if the requirement
-        // is not matched by the block, ignore it
-        if (targetGradleVersion == null || !targetGradleVersion.startsWith(ifgradleExpression)) {
+        // is not fulfilled by the block, ignore it
+        if (shouldIgnoreIfgradleBlock(ifgradleExpression)) {
           // Ignore this block
           ignoredBlockCount++
         }
@@ -82,5 +82,15 @@ class BuildScriptTemplateProcessor(private val targetGradleVersion: String?,
       }
     }
     return text2.toString()
+  }
+
+  private fun shouldIgnoreIfgradleBlock(version: String): Boolean {
+    if (targetGradleVersion == null) {
+      return true
+    }
+
+    val targetValue = SemanticVersion(targetGradleVersion)
+    val compareValue = SemanticVersion(version)
+    return compareValue > targetValue
   }
 }

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/projects/SemanticVersion.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/projects/SemanticVersion.kt
@@ -1,0 +1,67 @@
+package de.mannodermaus.gradle.plugins.junit5.util.projects
+
+import java.util.*
+
+private val NUMERICAL_REGEX = Regex("(\\d+)")
+
+/**
+ * Wrapper for a semantic version string (e.g. "6.0" or "7.1.5-alpha-12"),
+ * interpreting that string as a numerical value eligible for comparisons against other objects.
+ */
+class SemanticVersion(version: String): Comparable<SemanticVersion> {
+  val stableValue: Int = version.extractStableValue()
+  val suffixValue: Int = version.extractSuffixValue()
+
+  override fun compareTo(other: SemanticVersion): Int {
+    val result = this.stableValue.compareTo(other.stableValue)
+    return if (result == 0) {
+      this.suffixValue.compareTo(other.suffixValue)
+    } else {
+      result
+    }
+  }
+}
+
+/* Private */
+
+private fun String.extractStableValue(): Int {
+  val stripped = this.substringBefore('-')
+  val split = stripped.split('.').map {
+    it.toIntOrNull() ?: throw IllegalArgumentException("unknown stable value for version: $this")
+  }
+
+  require(split.size in 2..3) {
+    "unsupported number of components for version: $this"
+  }
+
+  // Add up the components, with the patch component being optional
+  return split[0] * 10000 +
+      split[1] * 100 +
+      if (split.size > 2) split[2] else 0
+}
+
+private fun String.extractSuffixValue(): Int {
+  if ('-' in this) {
+    val suffix = this
+        .substringAfter('-')
+        .toLowerCase(Locale.ROOT)
+
+    // Find known suffix types
+    val suffixMultiplier = when {
+      "alpha" in suffix -> 1
+      "beta" in suffix -> 100
+      "rc" in suffix -> 10000
+      else -> throw IllegalArgumentException("unknown suffix category for version: $this")
+    }
+
+    // Find numerical value of suffix
+    val numericalSuffix = NUMERICAL_REGEX.find(suffix)?.groupValues?.lastOrNull()?.toIntOrNull()
+        ?: throw IllegalArgumentException("unknown numerical suffix value for version: $this")
+
+    return suffixMultiplier * numericalSuffix
+
+  } else {
+    // Not a preview version - use highest possible suffix value to be "newer" than any preview could be
+    return Int.MAX_VALUE
+  }
+}

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/projects/SemanticVersionTests.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/projects/SemanticVersionTests.kt
@@ -1,0 +1,83 @@
+package de.mannodermaus.gradle.plugins.junit5.util.projects
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+@Suppress("unused")
+class SemanticVersionTests {
+
+  companion object {
+    @JvmStatic
+    fun dataParseTests() = listOf(
+        Arguments.of("5.0", 50000, Int.MAX_VALUE),
+        Arguments.of("6.6.1-alpha1", 60601, 1),
+        Arguments.of("6.6.1-beta1", 60601, 100),
+        Arguments.of("6.6.1", 60601, Int.MAX_VALUE),
+        Arguments.of("6.6-ALPHA-1", 60600, 1),
+        Arguments.of("6.6-alpha1", 60600, 1),
+        Arguments.of("6.6-alpha12", 60600, 12),
+        Arguments.of("7.0.1-beta05", 70001, 500),
+        Arguments.of("7.0.1-beta5", 70001, 500),
+        Arguments.of("8.0.0-rc1", 80000, 10000),
+        Arguments.of("8.0.0-rc-1", 80000, 10000),
+        Arguments.of("11.4.3-rc-10", 110403, 100000),
+        Arguments.of("99.15.67", 991567, Int.MAX_VALUE)
+    )
+
+    @JvmStatic
+    fun dataCompareTo() = listOf(
+        Arguments.of("4.4.0", "5.7.2", -1),
+        Arguments.of("4.4.0", "4.5.0", -1),
+        Arguments.of("4.4.2", "4.4.1", 1),
+        Arguments.of("4.4.0-alpha-1", "4.4.0-alpha5", -1),
+        Arguments.of("7.2-alpha-4", "7.2-beta-6", -1),
+        Arguments.of("7.4-beta-1", "7.3-beta-2", 1),
+        Arguments.of("8.0", "8.0.0-alpha-2", 1),
+        Arguments.of("2.5", "2.5.0", 0),
+        Arguments.of("4.2-rc-50", "4.2", -1),
+        Arguments.of("4.2.1-rc-50", "4.2", 1)
+    )
+
+    @JvmStatic
+    fun dataIncorrectInput() = listOf(
+        Arguments.of("2", "unsupported number of components for version: %s"),
+        Arguments.of("1.6.2.0", "unsupported number of components for version: %s"),
+        Arguments.of("ONE DOT TWO", "unknown stable value for version: %s"),
+        Arguments.of("ONE DOT TWO-alpha-1", "unknown stable value for version: %s"),
+        Arguments.of("2.zErO.6", "unknown stable value for version: %s"),
+        Arguments.of("1.5-preview-4", "unknown suffix category for version: %s"),
+        Arguments.of("3.2.0-3", "unknown suffix category for version: %s"),
+        Arguments.of("2.4-ALPHA", "unknown numerical suffix value for version: %s")
+    )
+  }
+
+  @MethodSource("dataParseTests")
+  @ParameterizedTest
+  fun `parse version into stable and suffix parts correctly`(input: String, expectedStable: Int, expectedSuffix: Int) {
+    val actual = SemanticVersion(input)
+
+    assertThat(actual.stableValue).isEqualTo(expectedStable)
+    assertThat(actual.suffixValue).isEqualTo(expectedSuffix)
+  }
+
+  @MethodSource("dataCompareTo")
+  @ParameterizedTest
+  fun `compares versions correctly`(version1: SemanticVersion, version2: SemanticVersion, expectedResult: Int) {
+    val actualResult = version1.compareTo(version2)
+
+    assertThat(actualResult).isEqualTo(expectedResult)
+  }
+
+  @MethodSource("dataIncorrectInput")
+  @ParameterizedTest
+  fun `throws on incorrect inputs`(version: String, expectedError: String) {
+    val exception = assertThrows<IllegalArgumentException> {
+      SemanticVersion(version)
+    }
+
+    assertThat(exception).hasMessageThat().isEqualTo(expectedError.format(version))
+  }
+}


### PR DESCRIPTION
With the new `SemanticVersion` type, it's possible to compare `$IFGRADLE{}` statements in the build file for the `FunctionalTests` in a smarter way than just comparing strings. This old approach doesn't work anymore since the expression must handle e.g. "6.5 and greater" instead of "just 6.5".

As a side note, thie PR updates to JUnit 5.7.0.