### PR TITLE
Provide configuration parameters to instrumentation tests

### DIFF
--- a/instrumentation/runner/src/main/java/de/mannodermaus/junit5/AndroidJUnit5.java
+++ b/instrumentation/runner/src/main/java/de/mannodermaus/junit5/AndroidJUnit5.java
@@ -46,6 +46,7 @@ public final class AndroidJUnit5 extends Runner {
 
   private static final String ARG_ENVIRONMENT_VARIABLES = "environmentVariables";
   private static final String ARG_SYSTEM_PROPERTIES = "systemProperties";
+  private static final String ARG_CONFIGURATION_PARAMETERS = "configurationParameters";
 
   private final Class<?> testClass;
   private final Launcher launcher = LauncherFactory.create();
@@ -84,6 +85,15 @@ public final class AndroidJUnit5 extends Runner {
       systemProperties = Collections.emptyMap();
     }
 
+    // Parse configuration parameters
+    Map<String, String> configurationParameters;
+    String configurationParametersArgument = arguments.getString(ARG_CONFIGURATION_PARAMETERS);
+    if (configurationParametersArgument != null) {
+      configurationParameters = PropertiesParser.fromString(configurationParametersArgument);
+    } else {
+      configurationParameters = Collections.emptyMap();
+    }
+
     // Parse the selectors to use from what's handed to the runner.
     List<DiscoverySelector> selectors = ParsedSelectors.fromBundle(testClass, arguments);
 
@@ -93,7 +103,12 @@ public final class AndroidJUnit5 extends Runner {
     // the filters to apply by the AndroidJUnit5 runner.
     List<Filter<?>> filters = GeneratedFilters.fromContext(instrumentation.getContext());
 
-    return new AndroidJUnit5RunnerParams(selectors, filters, environmentVariables, systemProperties);
+    return new AndroidJUnit5RunnerParams(selectors,
+        filters,
+        environmentVariables,
+        systemProperties,
+        configurationParameters
+    );
   }
 
   @Override

--- a/instrumentation/runner/src/main/java/de/mannodermaus/junit5/AndroidJUnit5RunnerParams.kt
+++ b/instrumentation/runner/src/main/java/de/mannodermaus/junit5/AndroidJUnit5RunnerParams.kt
@@ -9,12 +9,14 @@ data class AndroidJUnit5RunnerParams(
     private val selectors: List<DiscoverySelector> = emptyList(),
     private val filters: List<Filter<*>> = emptyList(),
     val environmentVariables: Map<String, String> = emptyMap(),
-    val systemProperties: Map<String, String> = emptyMap()
+    val systemProperties: Map<String, String> = emptyMap(),
+    private val configurationParameters: Map<String, String> = emptyMap()
 ) {
 
   fun createDiscoveryRequest(): LauncherDiscoveryRequest =
       LauncherDiscoveryRequestBuilder.request()
           .selectors(this.selectors)
           .filters(*this.filters.toTypedArray())
+          .configurationParameters(this.configurationParameters)
           .build()
 }


### PR DESCRIPTION
Include them in the discovery request created by the JUnit 5 Runner. This allows auto-detection of extensions, for example. Reuse the same mechanism for parsing as exercised for system properties & env vars, using the PropertiesParser to split a comma-separated string of key-value pairs.

This will resolve #229 