### PR TITLE
Automatically exclude JUnit 5 metadata files

### DIFF
--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Plugin.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/Plugin.kt
@@ -45,6 +45,10 @@ class AndroidJUnitPlatformPlugin : Plugin<Project> {
   }
 
   private fun Project.configureExtensions() {
+    // Add default ignore rules for JUnit 5 metadata files to the packaging options of the plugin,
+    // so that consumers don't need to do this explicitly
+    excludedPackagingOptions().forEach(android.packagingOptions::exclude)
+
     // Hook the JUnit Platform configuration into the Android testOptions
     attachDsl(this, projectConfig)
   }

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/Extensions.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/Extensions.kt
@@ -33,6 +33,11 @@ import java.util.Properties
 
 /* General */
 
+internal fun excludedPackagingOptions() = listOf(
+  "/META-INF/LICENSE.md",
+  "/META-INF/LICENSE-notice.md"
+)
+
 internal fun requireGradle(version: String, message: () -> String) {
   require(GradleVersion.current() >= GradleVersion.version(version)) {
     throw GradleException(message())


### PR DESCRIPTION
The default PackagingOptions catch a lot of these META-INF files already, but JUnit dependencies have Markdown versions of their licenses, which trip up the instrumentation tests ("duplicate file entry" etc).