### PR TITLE
Remove obsolete dexOptions

### DIFF
--- a/build-logic/src/main/kotlin/Environment.kt
+++ b/build-logic/src/main/kotlin/Environment.kt
@@ -29,7 +29,6 @@ enum class SupportedAgp(
 
 object Android {
     const val compileSdkVersion = "android-28"
-    const val javaMaxHeapSize = "3g"
 
     const val targetSdkVersion = 28
     const val sampleMinSdkVersion = 14

--- a/instrumentation/core/build.gradle.kts
+++ b/instrumentation/core/build.gradle.kts
@@ -31,10 +31,6 @@ val javaVersion = JavaVersion.VERSION_1_8
 android {
   compileSdkVersion(Android.compileSdkVersion)
 
-  dexOptions {
-    javaMaxHeapSize = Android.javaMaxHeapSize
-  }
-
   defaultConfig {
     minSdkVersion(Android.testCoreMinSdkVersion)
     targetSdkVersion(Android.targetSdkVersion)

--- a/instrumentation/runner/build.gradle.kts
+++ b/instrumentation/runner/build.gradle.kts
@@ -30,10 +30,6 @@ val javaVersion = JavaVersion.VERSION_1_8
 android {
   compileSdkVersion(Android.compileSdkVersion)
 
-  dexOptions {
-    javaMaxHeapSize = Android.javaMaxHeapSize
-  }
-
   defaultConfig {
     minSdkVersion(Android.testRunnerMinSdkVersion)
     targetSdkVersion(Android.targetSdkVersion)

--- a/instrumentation/sample/build.gradle.kts
+++ b/instrumentation/sample/build.gradle.kts
@@ -39,10 +39,6 @@ val javaVersion = JavaVersion.VERSION_1_8
 android {
   compileSdkVersion(Android.compileSdkVersion)
 
-  dexOptions {
-    javaMaxHeapSize = Android.javaMaxHeapSize
-  }
-
   defaultConfig {
     applicationId = "de.mannodermaus.junit5.sample"
     minSdkVersion(Android.sampleMinSdkVersion)


### PR DESCRIPTION
Based on warnings from AGP 7.0+ the entire `dexOptions` block is obsolete and has no effect when R8 is used.

The closest to documentation I could find about the deprecation of `dexOptions` were
- [this issue about the error message not being clear](https://issuetracker.google.com/issues/183295952)
- [the AGP source code which reports the deprecation](https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/internal/errors/DeprecationReporter.kt;l=59)

Should fix #258.