### PR TITLE
Replacing deprecated method

### DIFF
--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/AndroidJUnit5JacocoReport.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/AndroidJUnit5JacocoReport.kt
@@ -93,7 +93,7 @@ public abstract class AndroidJUnit5JacocoReport : JacocoReport() {
             )
 
             allReports.forEach { (from, to) ->
-                to.isEnabled = from.enabled
+                to.required.set(from.enabled)
                 from.destination?.let { to.destination = it }
             }
 


### PR DESCRIPTION
We have a warning in our build about this deprecated method. I'm replacing it with the new recommended method.

https://docs.gradle.org/current/javadoc/org/gradle/api/reporting/ConfigurableReport.html#setEnabled-boolean-
