### PR TITLE
Support Gradle configuration cache

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2,6 +2,7 @@ Change Log
 ==========
 
 ## Unreleased
+- Support Gradle configuration cache (#265)
 
 ## 1.8.2.0 (2021-12-19)
 - JUnit 5.8.2

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/AndroidJUnit5WriteFilters.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/AndroidJUnit5WriteFilters.kt
@@ -54,8 +54,6 @@ public abstract class AndroidJUnit5WriteFilters : DefaultTask() {
     }
   }
 
-  private lateinit var variant: TestVariant
-
   @Input
   public var includeTags: List<String> = emptyList()
 
@@ -102,7 +100,6 @@ public abstract class AndroidJUnit5WriteFilters : DefaultTask() {
     val type = AndroidJUnit5WriteFilters::class.java
 
     fun execute(task: AndroidJUnit5WriteFilters) {
-      task.variant = instrumentationTestVariant
       task.outputFolder = outputFolder
 
       // Access filters for this particular variant & provide them to the task, too

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/ConfigurationCacheTests.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/ConfigurationCacheTests.kt
@@ -1,0 +1,96 @@
+package de.mannodermaus.gradle.plugins.junit5
+
+import de.mannodermaus.gradle.plugins.junit5.annotations.DisabledOnCI
+import de.mannodermaus.gradle.plugins.junit5.util.TestEnvironment
+import de.mannodermaus.gradle.plugins.junit5.util.assertThat
+import de.mannodermaus.gradle.plugins.junit5.util.projects.FunctionalTestProjectCreator
+import de.mannodermaus.gradle.plugins.junit5.util.withPrunedPluginClasspath
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome.FAILED
+import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+@TestInstance(PER_CLASS)
+@DisabledOnCI
+class ConfigurationCacheTests {
+
+    private val environment = TestEnvironment()
+    private val agp = environment.supportedAgpVersions.last()
+    private lateinit var projectCreator: FunctionalTestProjectCreator
+
+    @BeforeAll
+    fun beforeAll(@TempDir folder: File) {
+        projectCreator = FunctionalTestProjectCreator(folder, environment)
+        println("Running configuration cache tests against latest AGP ($agp)...")
+    }
+
+    @Test
+    fun `test instrumentation tasks`() {
+        // Test configuration cache with one specific project and AGP version
+        val spec = projectCreator.specNamed("instrumentation-tests")
+        val project = projectCreator.createProject(spec, agp)
+
+        // Run it once; this is supposed to fail, but JUST because of 'no connected device',
+        // not because of other errors including the configuration cache.
+        runGradle(project, "connectedCheck", expectSuccess = false).assertWithLogging {
+            assertThat(it).task(":connectedDebugAndroidTest").hasOutcome(FAILED)
+            assertThat(it).output().contains("DeviceException: No connected devices!")
+        }
+
+        // Run it again, expecting to see a successful reuse of the configuration cache
+        runGradle(project, "connectedCheck", expectSuccess = false).assertWithLogging {
+            assertThat(it).output().contains("Reusing configuration cache.")
+        }
+    }
+
+    @Test
+    fun `test unit tasks`() {
+        val spec = projectCreator.specNamed("product-flavors")
+        val project = projectCreator.createProject(spec, agp)
+
+        runGradle(project, "test", expectSuccess = true).assertWithLogging {
+            assertThat(it).task(":test").hasOutcome(SUCCESS)
+        }
+
+        runGradle(project, "test", expectSuccess = true).assertWithLogging {
+            assertThat(it).output().contains("Reusing configuration cache.")
+        }
+    }
+
+    /* Private */
+
+    private fun runGradle(project: File, task: String, expectSuccess: Boolean) =
+        GradleRunner.create()
+            .withProjectDir(project)
+            .apply { agp.requiresGradle?.let(::withGradleVersion) }
+            .withArguments("--configuration-cache", task)
+            .withPrunedPluginClasspath(agp)
+            .run {
+                if (expectSuccess) build()
+                else buildAndFail()
+            }
+
+    private fun BuildResult.prettyPrint() {
+        // Indent every line to separate it from 'actual' Gradle output
+        val prefix = "[BuildResult-${hashCode()}]    "
+        val fixedOutput = this.output.lines()
+            .joinToString("\n") { "$prefix$it" }
+
+        println(fixedOutput)
+    }
+
+    private fun BuildResult.assertWithLogging(block: (BuildResult) -> Unit) {
+        try {
+            block(this)
+        } catch (e: Throwable) {
+            this.prettyPrint()
+            throw e
+        }
+    }
+}

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/projects/FunctionalTestProjectCreator.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/projects/FunctionalTestProjectCreator.kt
@@ -38,6 +38,10 @@ class FunctionalTestProjectCreator(
       ?: emptyList()
   }
 
+  fun specNamed(name: String): Spec =
+    allSpecs.firstOrNull { it.name == name }
+      ?: throw IllegalAccessException("No test project named '$name' found in src/test/resources/test-projects")
+
   @Throws(TestAbortedException::class)
   fun createProject(spec: Spec, agp: TestedAgp): File {
     // Validate the spec requirement against the executing AGP version first
@@ -55,6 +59,11 @@ class FunctionalTestProjectCreator(
       File(projectFolder, OUTPUT_SETTINGS_GRADLE_NAME).delete()
     }
     projectFolder.mkdirs()
+
+    // Set up static files
+    File(projectFolder, "gradle.properties").bufferedWriter().use { file ->
+      file.write("android.useAndroidX = true")
+    }
 
     // Copy over the source folders
     val targetSrcFolder = File(projectFolder, "src").also { it.mkdir() }

--- a/plugin/android-junit5/src/test/resources/test-projects/build.gradle.kts.template
+++ b/plugin/android-junit5/src/test/resources/test-projects/build.gradle.kts.template
@@ -54,6 +54,11 @@ android {
     minSdkVersion(minSdk)
     targetSdkVersion(targetSdk)
 
+    {% if INCLUDE_ANDROID_RESOURCES %}
+      testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+      testInstrumentationRunnerArguments["runnerBuilder"] = "de.mannodermaus.junit5.AndroidJUnit5Builder"
+    {% endif %}
+
     {% if USE_CUSTOM_BUILD_TYPE %}
       buildTypes {
         register("{{ USE_CUSTOM_BUILD_TYPE }}")
@@ -142,6 +147,9 @@ dependencies {
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}")
 
   {% if INCLUDE_ANDROID_RESOURCES %}
+    androidTestImplementation("androidx.test:runner:1.4.0")
+    androidTestImplementation("org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}")
+
     androidTestImplementation("de.mannodermaus.junit5:android-test-core:${junit5AndroidLibsVersion}")
     androidTestRuntimeOnly("de.mannodermaus.junit5:android-test-runner:${junit5AndroidLibsVersion}")
   {% endif %}

--- a/plugin/android-junit5/src/test/resources/test-projects/instrumentation-tests/config.toml
+++ b/plugin/android-junit5/src/test/resources/test-projects/instrumentation-tests/config.toml
@@ -1,0 +1,10 @@
+[settings]
+includeAndroidResources = true
+
+[[expectations]]
+buildType = "debug"
+tests = "AndroidTest"
+
+[[expectations]]
+buildType = "release"
+tests = "AndroidTest"

--- a/plugin/android-junit5/src/test/resources/test-projects/instrumentation-tests/src/androidTest/java/de/mannodermaus/app/InstrumentationTest.java
+++ b/plugin/android-junit5/src/test/resources/test-projects/instrumentation-tests/src/androidTest/java/de/mannodermaus/app/InstrumentationTest.java
@@ -1,0 +1,9 @@
+package de.mannodermaus.app;
+
+import org.junit.jupiter.api.Test;
+
+class InstrumentationTest {
+  @Test
+  void test() {
+  }
+}

--- a/plugin/android-junit5/src/test/resources/test-projects/instrumentation-tests/src/main/AndroidManifest.xml
+++ b/plugin/android-junit5/src/test/resources/test-projects/instrumentation-tests/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="de.mannodermaus.app"></manifest>

--- a/plugin/android-junit5/src/test/resources/test-projects/instrumentation-tests/src/main/java/de/mannodermaus/app/Adder.java
+++ b/plugin/android-junit5/src/test/resources/test-projects/instrumentation-tests/src/main/java/de/mannodermaus/app/Adder.java
@@ -1,0 +1,7 @@
+package de.mannodermaus.app;
+
+public class Adder {
+  public int add(int a, int b) {
+    return a + b;
+  }
+}

--- a/plugin/android-junit5/src/test/resources/test-projects/instrumentation-tests/src/test/java/de/mannodermaus/app/AndroidTest.java
+++ b/plugin/android-junit5/src/test/resources/test-projects/instrumentation-tests/src/test/java/de/mannodermaus/app/AndroidTest.java
@@ -1,0 +1,14 @@
+package de.mannodermaus.app;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import java.io.InputStream;
+
+class AndroidTest {
+  @Test
+  void test() {
+    InputStream is = getClass().getResourceAsStream("/com/android/tools/test_config.properties");
+    assertNotNull(is);
+  }
+}


### PR DESCRIPTION
The `xxxWriteFilters` tasks declared a field that wasn't serializable, preventing issues with the configuration cache. Turns out that the field is 100% unnecessary and can be safely removed.

Introduce a unit test infrastructure with functional tests to verify the interactions of the plugin with the configuration cache in the future.

#265