### PR TITLE
Update formatting of instrumentation test names to prevent breaking log file generation in AGP 7.1+

### DIFF
--- a/instrumentation/CHANGELOG.md
+++ b/instrumentation/CHANGELOG.md
@@ -2,6 +2,7 @@ Change Log
 ==========
 
 ## Unreleased
+- Update formatting of instrumentation test names to prevent breaking generation of log files in newer versions of AGP (#263)
 
 ## 1.3.0 (2021-09-17)
 

--- a/instrumentation/runner/src/main/kotlin/de/mannodermaus/junit5/internal/runners/AndroidJUnitPlatformTestTree.kt
+++ b/instrumentation/runner/src/main/kotlin/de/mannodermaus/junit5/internal/runners/AndroidJUnitPlatformTestTree.kt
@@ -50,7 +50,12 @@ internal class AndroidJUnitPlatformTestTree(
                 }
 
                 nameComponents.reverse()
-                nameComponents.joinToString(": ")
+
+                // Android's Unified Test Platform (AGP 7.0+) is using literal test names
+                // to create files when capturing Logcat output during execution.
+                // Ergo, make sure that only legal characters are being used in the test names
+                // (ref. https://github.com/mannodermaus/android-junit5/issues/263)
+                nameComponents.joinToString(" - ")
             }
 
             else -> formatTestName(identifier)


### PR DESCRIPTION
#263 