### PR TITLE
Fixing inherited test support

### DIFF
--- a/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/inheritance/TestExecutor.kt
+++ b/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/inheritance/TestExecutor.kt
@@ -1,0 +1,14 @@
+package de.mannodermaus.junit5.inheritance
+
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+abstract class TestExecutor {
+
+    @Test
+    fun executeTest() {
+        assertNotNull(getFilename())
+    }
+
+    abstract fun getFilename(): String?
+}

--- a/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/inheritance/TestImplementation.java
+++ b/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/inheritance/TestImplementation.java
@@ -1,0 +1,9 @@
+package de.mannodermaus.junit5.inheritance;
+
+public class TestImplementation extends TestExecutor {
+
+    @Override
+    public String getFilename() {
+        return "test";
+    }
+}

--- a/instrumentation/runner/src/main/kotlin/de/mannodermaus/junit5/AndroidJUnit5Builder.kt
+++ b/instrumentation/runner/src/main/kotlin/de/mannodermaus/junit5/AndroidJUnit5Builder.kt
@@ -65,6 +65,17 @@ public class AndroidJUnit5Builder : RunnerBuilder() {
             }
 
             if (testClass.jupiterTestMethods().isEmpty()) {
+
+                var C: Class<*>? = testClass
+                while (C != null) {
+
+                    C = C.superclass
+
+                    if(!C.jupiterTestMethods().isEmpty()) {
+                        return createJUnit5Runner(testClass)
+                    }
+                }
+
                 return null
             }
 

--- a/instrumentation/runner/src/main/kotlin/de/mannodermaus/junit5/AndroidJUnit5Builder.kt
+++ b/instrumentation/runner/src/main/kotlin/de/mannodermaus/junit5/AndroidJUnit5Builder.kt
@@ -71,8 +71,10 @@ public class AndroidJUnit5Builder : RunnerBuilder() {
 
                     C = C.superclass
 
-                    if(!C.jupiterTestMethods().isEmpty()) {
-                        return createJUnit5Runner(testClass)
+                    if(C != null) {
+                        if(!C.jupiterTestMethods().isEmpty()) {
+                            return createJUnit5Runner(testClass)
+                        }
                     }
                 }
 


### PR DESCRIPTION
Junit anotations of super classes was not scanned and classes was not recognized as tests.
`org.junit.runners.model.InvalidTestClassError: Invalid test class 'de.mannodermaus.junit5.inheritance.TestImplementation`