### PR TITLE
Add support for inherited tests

### DIFF
--- a/instrumentation/CHANGELOG.md
+++ b/instrumentation/CHANGELOG.md
@@ -4,6 +4,7 @@ Change Log
 ## Unreleased
 - Update formatting of instrumentation test names to prevent breaking generation of log files in newer versions of AGP (#263)
 - Add support for test sharding (#270)
+- Add support for inherited tests (#288)
 
 ## 1.3.0 (2021-09-17)
 

--- a/instrumentation/core/build.gradle.kts
+++ b/instrumentation/core/build.gradle.kts
@@ -72,6 +72,7 @@ junitPlatform {
 
 tasks.withType<KotlinCompile> {
   kotlinOptions.jvmTarget = javaVersion.toString()
+  kotlinOptions.freeCompilerArgs = listOf("-Xjvm-default=all")
 }
 
 tasks.withType<Test> {

--- a/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/inheritance/JavaAbstractClass.java
+++ b/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/inheritance/JavaAbstractClass.java
@@ -1,0 +1,14 @@
+package de.mannodermaus.junit5.inheritance;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+abstract class JavaAbstractClass {
+  @Test
+  void javaTest() {
+    assertNotNull(getJavaFileName());
+  }
+
+  abstract String getJavaFileName();
+}

--- a/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/inheritance/JavaAbstractClassTest.java
+++ b/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/inheritance/JavaAbstractClassTest.java
@@ -1,0 +1,11 @@
+package de.mannodermaus.junit5.inheritance;
+
+import androidx.annotation.Nullable;
+
+public class JavaAbstractClassTest extends JavaAbstractClass {
+  @Nullable
+  @Override
+  public String getJavaFileName() {
+    return "hello world";
+  }
+}

--- a/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/inheritance/JavaInterface.java
+++ b/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/inheritance/JavaInterface.java
@@ -1,0 +1,12 @@
+package de.mannodermaus.junit5.inheritance;
+
+import org.junit.jupiter.api.Test;
+
+interface JavaInterface {
+   @Test
+   default void javaTest() {
+      assert(getJavaValue() > 0L);
+   }
+
+   long getJavaValue();
+}

--- a/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/inheritance/JavaInterfaceTest.java
+++ b/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/inheritance/JavaInterfaceTest.java
@@ -1,0 +1,8 @@
+package de.mannodermaus.junit5.inheritance;
+
+public class JavaInterfaceTest implements JavaInterface {
+  @Override
+  public long getJavaValue() {
+    return 4815162342L;
+  }
+}

--- a/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/inheritance/JavaMixedInterfaceTest.java
+++ b/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/inheritance/JavaMixedInterfaceTest.java
@@ -1,0 +1,13 @@
+package de.mannodermaus.junit5.inheritance;
+
+public class JavaMixedInterfaceTest implements JavaInterface, KotlinInterface {
+  @Override
+  public long getJavaValue() {
+    return 4815162342L;
+  }
+
+  @Override
+  public int getKotlinValue() {
+    return 10101010;
+  }
+}

--- a/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/inheritance/KotlinInheritanceTests.kt
+++ b/instrumentation/core/src/androidTest/java/de/mannodermaus/junit5/inheritance/KotlinInheritanceTests.kt
@@ -1,0 +1,35 @@
+package de.mannodermaus.junit5.inheritance
+
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+abstract class KotlinAbstractClass {
+    @Test
+    fun kotlinTest() {
+        assertNotNull(getKotlinFileName())
+    }
+
+    abstract fun getKotlinFileName(): String?
+}
+
+interface KotlinInterface {
+    @Test
+    fun kotlinTest() {
+        assert(kotlinValue > 0)
+    }
+
+    val kotlinValue: Int
+}
+
+class KotlinAbstractClassTest : KotlinAbstractClass() {
+    override fun getKotlinFileName() = "hello world"
+}
+
+class KotlinInterfaceTest : KotlinInterface {
+    override val kotlinValue: Int = 1337
+}
+
+class KotlinMixedInterfaceTest : KotlinInterface, JavaInterface {
+    override val kotlinValue: Int = 1337
+    override fun getJavaValue(): Long = 1234L
+}

--- a/instrumentation/gradle/wrapper/gradle-wrapper.properties
+++ b/instrumentation/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/instrumentation/runner/src/test/kotlin/de/mannodermaus/junit5/TestClasses.kt
+++ b/instrumentation/runner/src/test/kotlin/de/mannodermaus/junit5/TestClasses.kt
@@ -81,3 +81,23 @@ class HasTaggedTest {
 
   }
 }
+
+abstract class AbstractTestClass {
+  @Test
+  fun abstractTest() {
+  }
+}
+
+interface AbstractTestInterface {
+  @Test
+  fun interfaceTest() {
+  }
+}
+
+class HasInheritedTestsFromClass : AbstractTestClass() {
+  @Test
+  fun method() {
+  }
+}
+
+class HasInheritedTestsFromInterface : AbstractTestInterface

--- a/instrumentation/runner/src/test/kotlin/de/mannodermaus/junit5/internal/ExtensionsTests.kt
+++ b/instrumentation/runner/src/test/kotlin/de/mannodermaus/junit5/internal/ExtensionsTests.kt
@@ -5,6 +5,8 @@ package de.mannodermaus.junit5.internal
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import de.mannodermaus.junit5.DoesntHaveTestMethods
+import de.mannodermaus.junit5.HasInheritedTestsFromClass
+import de.mannodermaus.junit5.HasInheritedTestsFromInterface
 import de.mannodermaus.junit5.HasInnerClassWithTest
 import de.mannodermaus.junit5.HasParameterizedTest
 import de.mannodermaus.junit5.HasRepeatedTest
@@ -49,7 +51,7 @@ class ExtensionsTests {
       )
       AndroidJUnit5(klass, params).run(notifier)
 
-      assertWithMessage("Executed ${listener.count()} instead of $expectExecutedTests tests: '${listener.methodNames()}'")
+      assertWithMessage("Executed ${listener.count()} instead of $expectExecutedTests tests on class '${klass.simpleName}': '${listener.methodNames()}'")
           .that(listener.count())
           .isEqualTo(expectExecutedTests)
     }
@@ -87,7 +89,9 @@ class ExtensionsTests {
         Arguments.of(HasTestFactory::class.java, 2),
         Arguments.of(HasTestTemplate::class.java, 2),
         Arguments.of(HasParameterizedTest::class.java, 2),
-        Arguments.of(HasInnerClassWithTest::class.java, 1)
+        Arguments.of(HasInnerClassWithTest::class.java, 1),
+        Arguments.of(HasInheritedTestsFromClass::class.java, 2),
+        Arguments.of(HasInheritedTestsFromInterface::class.java, 1),
     )
   }
 }


### PR DESCRIPTION
Derived from the feature request expressed by https://github.com/mannodermaus/android-junit5/pull/278, add support for detecting inherited tests to the instrumentation runtime. This catches tests from both abstract classes and interfaces, mirroring the capabilities of JUnit Platform for unit tests.

The key to this change is to make `Class<*>.jupiterTestMethods` understand inherited methods, too. In contrast to the linked proposal, this will also correctly mark any inherited test as ignored on unsupported devices – therefore, the change should be made to the method, not the runner.

Verified by adding a bunch of instrumentation tests to `:core` and some new unit tests to `:runner`.