### PR TITLE
Configurable scenario supplier

### DIFF
--- a/instrumentation/compose/api/compose.api
+++ b/instrumentation/compose/api/compose.api
@@ -13,7 +13,8 @@ public final class de/mannodermaus/junit5/compose/AndroidComposeExtension : de/m
 }
 
 public final class de/mannodermaus/junit5/compose/AndroidComposeExtensionKt {
-	public static final fun createAndroidComposeExtension (Ljava/lang/Class;)Lde/mannodermaus/junit5/compose/AndroidComposeExtension;
+	public static final fun createAndroidComposeExtension (Ljava/lang/Class;Lkotlin/jvm/functions/Function0;)Lde/mannodermaus/junit5/compose/AndroidComposeExtension;
+	public static synthetic fun createAndroidComposeExtension$default (Ljava/lang/Class;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lde/mannodermaus/junit5/compose/AndroidComposeExtension;
 	public static final fun createComposeExtension ()Lde/mannodermaus/junit5/compose/ComposeExtension;
 }
 

--- a/instrumentation/compose/src/main/java/de/mannodermaus/junit5/compose/AndroidComposeExtension.kt
+++ b/instrumentation/compose/src/main/java/de/mannodermaus/junit5/compose/AndroidComposeExtension.kt
@@ -46,6 +46,11 @@ public inline fun <reified A : ComponentActivity> createAndroidComposeExtension(
     return createAndroidComposeExtension(A::class.java)
 }
 
+@ExperimentalTestApi
+public inline fun <reified A : ComponentActivity> createAndroidComposeExtension(noinline scenarioSupplier: () -> ActivityScenario<A>): AndroidComposeExtension<A> {
+    return createAndroidComposeExtension(A::class.java, scenarioSupplier)
+}
+
 /**
  * Factory method to provide a JUnit 5 extension for Compose using its [RegisterExtension] API
  * for field injection. Prefer this over [createComposeExtension] if your tests require a custom Activity.
@@ -54,11 +59,8 @@ public inline fun <reified A : ComponentActivity> createAndroidComposeExtension(
  * Activity to your app's manifest file.
  */
 @ExperimentalTestApi
-public fun <A : ComponentActivity> createAndroidComposeExtension(
-    activityClass: Class<A>, scenarioSupplier: () -> ActivityScenario<A> = {
-        ActivityScenario.launch(activityClass)
-    }
-): AndroidComposeExtension<A> {
+public fun <A : ComponentActivity> createAndroidComposeExtension(activityClass: Class<A>,
+                                                                 scenarioSupplier: () -> ActivityScenario<A> = { ActivityScenario.launch(activityClass) }): AndroidComposeExtension<A> {
     return AndroidComposeExtension(scenarioSupplier)
 }
 

--- a/instrumentation/compose/src/main/java/de/mannodermaus/junit5/compose/AndroidComposeExtension.kt
+++ b/instrumentation/compose/src/main/java/de/mannodermaus/junit5/compose/AndroidComposeExtension.kt
@@ -46,6 +46,14 @@ public inline fun <reified A : ComponentActivity> createAndroidComposeExtension(
     return createAndroidComposeExtension(A::class.java)
 }
 
+/**
+ * Factory method to provide a JUnit 5 extension for Compose using its [RegisterExtension] API
+ * for field injection. Prefer this over [createComposeExtension] if your tests require a custom Activity.
+ * This is usually the case for tests where the Compose content is set by that Activity, instead of
+ * via [ComposeContext.setContent], provided through the extension. Make sure that you add the provided
+ * Activity to your app's manifest file. This variant allows you to provide a custom [ActivityScenario]
+ * which is useful in cases where you may want to launch an activity with a custom intent, for example.
+ */
 @ExperimentalTestApi
 public inline fun <reified A : ComponentActivity> createAndroidComposeExtension(noinline scenarioSupplier: () -> ActivityScenario<A>): AndroidComposeExtension<A> {
     return createAndroidComposeExtension(A::class.java, scenarioSupplier)
@@ -56,7 +64,8 @@ public inline fun <reified A : ComponentActivity> createAndroidComposeExtension(
  * for field injection. Prefer this over [createComposeExtension] if your tests require a custom Activity.
  * This is usually the case for tests where the Compose content is set by that Activity, instead of
  * via [ComposeContext.setContent], provided through the extension. Make sure that you add the provided
- * Activity to your app's manifest file.
+ * Activity to your app's manifest file. You may also provide an optional [ActivityScenario] supplier
+ * which is useful in cases where you may want to launch an activity with a custom intent,for example.
  */
 @ExperimentalTestApi
 public fun <A : ComponentActivity> createAndroidComposeExtension(activityClass: Class<A>,

--- a/instrumentation/compose/src/main/java/de/mannodermaus/junit5/compose/AndroidComposeExtension.kt
+++ b/instrumentation/compose/src/main/java/de/mannodermaus/junit5/compose/AndroidComposeExtension.kt
@@ -55,13 +55,11 @@ public inline fun <reified A : ComponentActivity> createAndroidComposeExtension(
  */
 @ExperimentalTestApi
 public fun <A : ComponentActivity> createAndroidComposeExtension(
-    activityClass: Class<A>
+    activityClass: Class<A>, scenarioSupplier: () -> ActivityScenario<A> = {
+        ActivityScenario.launch(activityClass)
+    }
 ): AndroidComposeExtension<A> {
-    return AndroidComposeExtension(
-        scenarioSupplier = {
-            ActivityScenario.launch(activityClass)
-        }
-    )
+    return AndroidComposeExtension(scenarioSupplier)
 }
 
 /**


### PR DESCRIPTION
Based on this comment: https://github.com/mannodermaus/android-junit5/issues/234#issuecomment-1637154041 - I think this will let us be able to run Activities with an intent upon startup.

It still keeps the same behavior as present if the extra parameter is left out since it has a default value, but gives us the flexibility to use a scenario supplier that uses alternate `launch` options.

for instance we could now do something like:
```
@OptIn(ExperimentalTestApi::class)
@JvmField
@RegisterExtension
val extension = createAndroidComposeExtension<SomeActivity>(
  scenarioSupplier = { 
    val intent = Intent()
    intent.putExtra("someExtra", true)
    ActivityScenario.launch(intent)
  }
)
```

https://developer.android.com/reference/androidx/test/core/app/ActivityScenario#launch(android.content.Intent)