### PR TITLE
Address binary-incompatible API change between Gradle 7&8 for output location of Jacoco reports

### DIFF
--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/extensions/ConfigurableReportExt.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/extensions/ConfigurableReportExt.kt
@@ -2,6 +2,17 @@ package de.mannodermaus.gradle.plugins.junit5.internal.extensions
 
 import org.gradle.api.file.FileSystemLocationProperty
 import org.gradle.api.reporting.ConfigurableReport
+import java.lang.reflect.Method
 
-internal val ConfigurableReport.outputLocationFile
-    get() = outputLocation as? FileSystemLocationProperty<*>
+internal val ConfigurableReport.outputLocationFile: FileSystemLocationProperty<*>
+    get() = try {
+        outputLocation as FileSystemLocationProperty<*>
+    } catch (e: NoSuchMethodError) {
+        // Observed before Gradle 8.x
+        getOutputLocationMethod.invoke(this) as FileSystemLocationProperty<*>
+    }
+
+private val ConfigurableReport.getOutputLocationMethod: Method
+    get() = javaClass.declaredMethods.first { method ->
+        method.name == "getOutputLocation" && method.returnType == FileSystemLocationProperty::class.java
+    }

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/AndroidJUnit5JacocoReport.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/tasks/AndroidJUnit5JacocoReport.kt
@@ -98,7 +98,7 @@ public abstract class AndroidJUnit5JacocoReport : JacocoReport() {
 
             allReports.forEach { (from, to) ->
                 to.required.set(from.enabled)
-                from.destination?.let { to.outputLocationFile?.set(it) }
+                from.destination?.let { to.outputLocationFile.set(it) }
             }
 
             // Task-level Configuration

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/FunctionalTests.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/FunctionalTests.kt
@@ -67,12 +67,13 @@ class FunctionalTests {
                     val project = projectCreator.createProject(spec, agp)
 
                     // Execute the tests of the virtual project with Gradle
-                    val result = runGradle(agp)
+                    val taskName = spec.task ?: "test"
+                    val result = runGradle(agp, taskName)
                         .withProjectDir(project)
                         .build()
 
                     // Check that the task execution was successful in general
-                    when (val outcome = result.task(":test")?.outcome) {
+                    when (val outcome = result.task(":$taskName")?.outcome) {
                       TaskOutcome.UP_TO_DATE -> {
                         // Nothing to do, a previous build already checked this
                         println("Test task up-to-date; skipping assertions.")
@@ -122,14 +123,14 @@ class FunctionalTests {
         }
       }
 
-  private fun runGradle(agpVersion: TestedAgp) =
+  private fun runGradle(agpVersion: TestedAgp, task: String) =
       GradleRunner.create()
           .apply {
             if (agpVersion.requiresGradle != null) {
               withGradleVersion(agpVersion.requiresGradle)
             }
           }
-          .withArguments("test", "--stacktrace")
+          .withArguments(task, "--stacktrace")
           .withPrunedPluginClasspath(agpVersion)
 
   // Helper DSL to assert AGP-specific results of the virtual Gradle executions.

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/projects/FunctionalTestProjectCreator.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/projects/FunctionalTestProjectCreator.kt
@@ -74,6 +74,7 @@ class FunctionalTestProjectCreator(
     replacements["AGP_VERSION"] = agp.version
     replacements["USE_KOTLIN"] = spec.useKotlin
     replacements["USE_FLAVORS"] = spec.useFlavors
+    replacements["USE_JACOCO"] = spec.useJacoco
     replacements["USE_CUSTOM_BUILD_TYPE"] = spec.useCustomBuildType
     replacements["RETURN_DEFAULT_VALUES"] = spec.returnDefaultValues
     replacements["INCLUDE_ANDROID_RESOURCES"] = spec.includeAndroidResources
@@ -115,8 +116,10 @@ class FunctionalTestProjectCreator(
     val srcFolder: File,
     config: Config
   ) {
+    val task = config[TomlSpec.Settings.task]
     val minAgpVersion = config[TomlSpec.Settings.minAgpVersion]
     val useKotlin = config[TomlSpec.Settings.useKotlin]
+    val useJacoco = config[TomlSpec.Settings.useJacoco]
     val useFlavors = config[TomlSpec.Settings.useFlavors]
     val useCustomBuildType = config[TomlSpec.Settings.useCustomBuildType]
     val returnDefaultValues = config[TomlSpec.Settings.returnDefaultValues]
@@ -151,12 +154,14 @@ class FunctionalTestProjectCreator(
 
   // Structure of the virtual project config file, used only internally
   private object TomlSpec : ConfigSpec(prefix = "") {
-    val expectations by required<List<ExpectedTests>>()
+    val expectations by optional<List<ExpectedTests>>(default = emptyList())
 
     object Settings : ConfigSpec() {
+      val task by optional<String?>(default = null)
       val minAgpVersion by optional<String?>(default = null)
       val useFlavors by optional(default = false)
       val useKotlin by optional(default = false)
+      val useJacoco by optional(default = false)
       val useCustomBuildType by optional<String?>(default = null)
       val returnDefaultValues by optional(default = false)
       val includeAndroidResources by optional(default = false)

--- a/plugin/android-junit5/src/test/resources/test-projects/build.gradle.kts.template
+++ b/plugin/android-junit5/src/test/resources/test-projects/build.gradle.kts.template
@@ -29,6 +29,10 @@ plugins {
     id("org.jetbrains.kotlin.android")
   {% endif %}
 
+  {% if USE_JACOCO %}
+    jacoco
+  {% endif %}
+
   id("de.mannodermaus.android-junit5")
 }
 
@@ -116,11 +120,20 @@ android {
   }
 }
 
-{% if INCLUDE_ANDROID_RESOURCES %}
-  junitPlatform {
+junitPlatform {
+  {% if INCLUDE_ANDROID_RESOURCES %}
     instrumentationTests.integrityCheckEnabled = false
-  }
-{% endif %}
+  {% endif %}
+
+  {% if USE_JACOCO %}
+    jacocoOptions {
+      html {
+        enabled = true
+        destination = layout.buildDirectory.file("reports/jacoco/${name}.html").get().asFile
+      }
+    }
+  {% endif %}
+}
 
 {% for type in DISABLE_TESTS_FOR_BUILD_TYPES %}
   androidComponents {

--- a/plugin/android-junit5/src/test/resources/test-projects/jacoco/config.toml
+++ b/plugin/android-junit5/src/test/resources/test-projects/jacoco/config.toml
@@ -1,0 +1,4 @@
+[settings]
+useJacoco = true
+minAgpVersion = "7.4"
+task = "tasks"

--- a/plugin/android-junit5/src/test/resources/test-projects/jacoco/src/main/AndroidManifest.xml
+++ b/plugin/android-junit5/src/test/resources/test-projects/jacoco/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="de.mannodermaus.app"></manifest>

--- a/plugin/android-junit5/src/test/resources/test-projects/jacoco/src/main/java/de/mannodermaus/app/Adder.java
+++ b/plugin/android-junit5/src/test/resources/test-projects/jacoco/src/main/java/de/mannodermaus/app/Adder.java
@@ -1,0 +1,7 @@
+package de.mannodermaus.app;
+
+public class Adder {
+  public int add(int a, int b) {
+    return a + b;
+  }
+}


### PR DESCRIPTION
Resolves #302. There is a binary incompatibility between Gradle 7 and 8 that changed the return type
of `outputLocation`. Catch an error with the new method and fall back to a safe alternative.

First commit adds (failing) test cases, the second commit fixes the code. Extend the test infrastructure to allow test projects to toggle Jacoco on/off at will. Furthermore, allow some tests to only run from specific Gradle versions onwards