### PR TITLE
Update readme to make it more clear that you need to apply plugin as well in legacy syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,33 @@ To get started, declare the plugin in your `app` module's build script alongside
 
 ### Alternative: Legacy DSL
 
-If you prefer to use the legacy way to declare the dependency instead, remove the `version()` block from above and declare the plugin in your _root project's build script_ like so:
+If you prefer to use the legacy way to declare the dependency instead, remove the `version()` block from above and apply in your`app` module:
+
+<details>
+  <summary>Kotlin</summary>
+
+  ```kotlin
+   plugins {
+    id("de.mannodermaus.android-junit5")
+  }
+  ```  
+</details>
+
+<details>
+  <summary>Groovy</summary>
+
+  ```kotlin
+  plugins {
+    id "de.mannodermaus.android-junit5"
+  }
+  ```
+  or 
+  ```kotlin
+  apply plugin: 'de.mannodermaus.android-junit5'
+  ```
+</details>
+
+Then declare the plugin in your _root project's build script_ like so:
 
 <details>
   <summary>Kotlin</summary>

--- a/README.md.template
+++ b/README.md.template
@@ -62,7 +62,33 @@ To get started, declare the plugin in your `app` module's build script alongside
 
 ### Alternative: Legacy DSL
 
-If you prefer to use the legacy way to declare the dependency instead, remove the `version()` block from above and declare the plugin in your _root project's build script_ like so:
+If you prefer to use the legacy way to declare the dependency instead, remove the `version()` block from above and apply in your`app` module:
+
+<details>
+  <summary>Kotlin</summary>
+
+  ```kotlin
+   plugins {
+    id("de.mannodermaus.android-junit5")
+  }
+  ```  
+</details>
+
+<details>
+  <summary>Groovy</summary>
+
+  ```kotlin
+  plugins {
+    id "de.mannodermaus.android-junit5"
+  }
+  ```
+  or 
+  ```kotlin
+  apply plugin: 'de.mannodermaus.android-junit5'
+  ```
+</details>
+
+Then declare the plugin in your _root project's build script_ like so:
 
 <details>
   <summary>Kotlin</summary>


### PR DESCRIPTION
I was struggling for more then an hour to get my Junit5 tests to recognize. Turns out that I didn't see the subtle suggestion in the readme that you also need to apply the plugin. Closes #313 

So this PR makes it more explicit. 

