### PR TITLE
Fix inheritance hierarchy of `ComposeExtension`

### DIFF
--- a/instrumentation/CHANGELOG.md
+++ b/instrumentation/CHANGELOG.md
@@ -3,6 +3,8 @@ Change Log
 
 ## Unreleased
 
+- Fix inheritance hierarchy of `ComposeExtension` to avoid false-positive warning regarding `@RegisterExtension` (#318)
+
 ## 1.4.0 (2023-11-05)
 
 - Update formatting of instrumentation test names to prevent breaking generation of log files in newer versions of AGP (#263)

--- a/instrumentation/compose/api/compose.api
+++ b/instrumentation/compose/api/compose.api
@@ -31,7 +31,7 @@ public abstract interface class de/mannodermaus/junit5/compose/ComposeContext : 
 	public abstract fun waitUntil (JLkotlin/jvm/functions/Function0;)V
 }
 
-public abstract interface class de/mannodermaus/junit5/compose/ComposeExtension {
+public abstract interface class de/mannodermaus/junit5/compose/ComposeExtension : org/junit/jupiter/api/extension/Extension {
 	public abstract fun runComposeTest (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun use (Lkotlin/jvm/functions/Function1;)V
 }

--- a/instrumentation/compose/src/main/java/de/mannodermaus/junit5/compose/ComposeExtension.kt
+++ b/instrumentation/compose/src/main/java/de/mannodermaus/junit5/compose/ComposeExtension.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.extension.Extension
  * in a field within the test class using any of the [createComposeExtension] or
  * [createAndroidComposeExtension] factory methods.
  */
-public interface ComposeExtension {
+public interface ComposeExtension : Extension {
     /**
      * Set up and drive the execution of a Compose test within the provided [block].
      * Depending on the time this is called, it will either queue up a preparatory action for the test


### PR DESCRIPTION
This avoids a false-positive warning regarding RegisterExtension.

Resolves https://github.com/mannodermaus/android-junit5/issues/318