### PR TITLE
Fix sources.jar generation for instrumentation & plugin

### DIFF
--- a/build-logic/src/main/kotlin/Deployment.kt
+++ b/build-logic/src/main/kotlin/Deployment.kt
@@ -45,9 +45,11 @@ fun Project.configureDeployment(deployConfig: Deployed) {
         archiveClassifier.set("sources")
 
         if (isAndroid) {
-            from(android.sourceSets.main.java.srcDirs)
+            // This declaration includes Java source directories
+            from(android.sourceSets.main.kotlin.srcDirs)
         } else {
-            from(sourceSets.main.java.srcDirs)
+            // This declaration includes Kotlin & Groovy source directories
+            from(sourceSets.main.allJava.srcDirs)
         }
     }
 
@@ -294,11 +296,11 @@ private class AndroidDsl(project: Project) {
         class MainDsl(sourceSets: NamedDomainObjectCollection<Any>) {
             private val delegate = sourceSets.named("main").get()
 
-            val java = JavaDsl(delegate)
+            val kotlin = KotlinDsl(delegate)
 
-            class JavaDsl(main: Any) {
+            class KotlinDsl(main: Any) {
                 val srcDirs = main.javaClass
-                    .getDeclaredMethod("getJavaDirectories")
+                    .getDeclaredMethod("getKotlinDirectories")
                     .invoke(main) as Set<File>
             }
         }

--- a/plugin/android-junit5/build.gradle.kts
+++ b/plugin/android-junit5/build.gradle.kts
@@ -99,7 +99,7 @@ val versionClassTask = tasks.register<Copy>("createVersionClass") {
 }
 sourceSets {
     main {
-        java.srcDir(genFolder)
+        kotlin.srcDir(genFolder)
     }
 }
 tasks.withType<DokkaTask> {


### PR DESCRIPTION
Plugin, Instrumentation-Extensions & Instrumentation-Runner had essentially empty sources.jar artifacts because the current integration only looked into src/main/java, but these modules changed to src/main/kotlin already. Redefining the declaration makes all source folders appear now