### PR TITLE
Allow autoconfiguration of Compose integration via the plugin

### DIFF
--- a/README.md.template
+++ b/README.md.template
@@ -149,8 +149,8 @@ Can you think of more? Let's discuss in the issues section!
   <summary>Kotlin</summary>
 
   ```kotlin
-  dependencies {
-    androidTestImplementation("de.mannodermaus.junit5:android-test-extensions:${instrumentationVersion}")
+  junitPlatform {
+    instrumentationTests.includeExtensions.set(true)
   }
   ```
 </details>
@@ -159,8 +159,8 @@ Can you think of more? Let's discuss in the issues section!
   <summary>Groovy</summary>
 
   ```groovy
-  dependencies {
-    androidTestImplementation "de.mannodermaus.junit5:android-test-extensions:${instrumentationVersion}"
+  junitPlatform {
+    instrumentationTests.includeExtensions.set(true)
   }
   ```
 </details>
@@ -168,15 +168,16 @@ Can you think of more? Let's discuss in the issues section!
 ### Jetpack Compose
 
 To test `@Composable` functions on device with JUnit 5, first enable support for instrumentation tests as described above.
-Then, add the integration library for Jetpack Compose to the `androidTestImplementation` configuration:
+Then, add the Compose test dependency to your `androidTestImplementation` configuration
+and the plugin will autoconfigure JUnit 5 Compose support for you!
 
 <details open>
   <summary>Kotlin</summary>
   
   ```kotlin
   dependencies {
-    // Test extension & transitive dependencies
-    androidTestImplementation("de.mannodermaus.junit5:android-test-compose:${instrumentationVersion}")
+    // Compose test framework
+    androidTestImplementation("androidx.compose.ui:ui-test-android:$compose_version")
 
     // Needed for createComposeExtension() and createAndroidComposeExtension()
     debugImplementation("androidx.compose.ui:ui-test-manifest:$compose_version")
@@ -189,8 +190,8 @@ Then, add the integration library for Jetpack Compose to the `androidTestImpleme
 
   ```groovy
   dependencies {
-    // Test extension & transitive dependencies
-    androidTestImplementation "de.mannodermaus.junit5:android-test-compose:${instrumentationVersion}"
+    // Compose test framework
+    androidTestImplementation "androidx.compose.ui:ui-test-android:$compose_version"
 
     // Needed for createComposeExtension() and createAndroidComposeExtension()
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
@@ -199,6 +200,31 @@ Then, add the integration library for Jetpack Compose to the `androidTestImpleme
 </details>
 
 [The wiki][wiki-home] includes a section on how to test your Composables with JUnit 5.
+
+### Override the version of instrumentation test libraries
+
+By default, the plugin will make sure to use a compatible version of the instrumentation test libraries
+when it sets up the artifacts automatically. However, it is possible to choose a custom version instead via its DSL:
+
+<details open>
+  <summary>Kotlin</summary>
+
+  ```kotlin
+  junitPlatform {
+    instrumentationTests.version.set("${instrumentationVersion}")
+  }
+  ```
+</details>
+
+<details>
+  <summary>Groovy</summary>
+
+  ```groovy
+  junitPlatform {
+    instrumentationTests.version.set("${instrumentationVersion}")
+  }
+  ```
+</details>
 
 ## Official Support
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -7,6 +7,8 @@ Change Log
 - Allow overriding the version of the instrumentation libraries applied with the plugin
 - Update Jacoco & instrumentation test DSLs of the plugin to use Gradle Providers for their input parameters (e.g. `instrumentationTests.enabled.set(true)` instead of `instrumentationTests.enabled = true`)
 - Removed deprecated `integrityCheckEnabled` flag from the plugin DSL's instrumentation test options
+- Allow opt-in usage of extension library via the plugin's DSL
+- Allow autoconfiguration of compose library if Compose is used in the androidTest dependency list 
 
 ## 1.10.0.0 (2023-11-05)
 - JUnit 5.10.0

--- a/plugin/android-junit5/build.gradle.kts
+++ b/plugin/android-junit5/build.gradle.kts
@@ -88,6 +88,7 @@ val versionClassTask = tasks.register<Copy>("createVersionClass") {
         mapOf(
             "tokens" to mapOf(
                 "INSTRUMENTATION_GROUP" to Artifacts.Instrumentation.groupId,
+                "INSTRUMENTATION_COMPOSE" to Artifacts.Instrumentation.Compose.artifactId,
                 "INSTRUMENTATION_CORE" to Artifacts.Instrumentation.Core.artifactId,
                 "INSTRUMENTATION_EXTENSIONS" to Artifacts.Instrumentation.Extensions.artifactId,
                 "INSTRUMENTATION_RUNNER" to Artifacts.Instrumentation.Runner.artifactId,

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/configureJUnit5.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/configureJUnit5.kt
@@ -14,12 +14,16 @@ import de.mannodermaus.gradle.plugins.junit5.internal.config.PluginConfig
 import de.mannodermaus.gradle.plugins.junit5.internal.extensions.android
 import de.mannodermaus.gradle.plugins.junit5.internal.extensions.getAsList
 import de.mannodermaus.gradle.plugins.junit5.internal.extensions.getTaskName
+import de.mannodermaus.gradle.plugins.junit5.internal.extensions.hasDependency
 import de.mannodermaus.gradle.plugins.junit5.internal.extensions.junit5Warn
 import de.mannodermaus.gradle.plugins.junit5.internal.extensions.namedOrNull
+import de.mannodermaus.gradle.plugins.junit5.internal.extensions.usesComposeIn
+import de.mannodermaus.gradle.plugins.junit5.internal.extensions.usesJUnitJupiterIn
 import de.mannodermaus.gradle.plugins.junit5.internal.utils.excludedPackagingOptions
 import de.mannodermaus.gradle.plugins.junit5.tasks.AndroidJUnit5JacocoReport
 import de.mannodermaus.gradle.plugins.junit5.tasks.AndroidJUnit5WriteFilters
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency
 import org.gradle.api.tasks.testing.Test
 
 internal fun configureJUnit5(
@@ -109,11 +113,7 @@ private fun AndroidJUnitPlatformExtension.prepareInstrumentationTests(project: P
     if (!instrumentationTests.enabled.get()) return
 
     // Automatically configure instrumentation tests when JUnit 5 is detected in that configuration
-    val hasJupiterApi = project.configurations
-        .getByName("androidTestImplementation")
-        .dependencies
-        .any { it.group == "org.junit.jupiter" && it.name == "junit-jupiter-api" }
-    if (!hasJupiterApi) return
+    if (!project.usesJUnitJupiterIn("androidTestImplementation")) return
 
     // Attach the JUnit 5 RunnerBuilder to the list, unless it's already added
     val runnerBuilders = android.defaultConfig.testInstrumentationRunnerArguments.getAsList("runnerBuilder")
@@ -139,6 +139,13 @@ private fun AndroidJUnitPlatformExtension.prepareInstrumentationTests(project: P
         project.dependencies.add(
             "androidTestImplementation",
             "${Libraries.instrumentationExtensions}:$version"
+        )
+    }
+
+    if (project.usesComposeIn("androidTestImplementation")) {
+        project.dependencies.add(
+            "androidTestImplementation",
+            "${Libraries.instrumentationCompose}:$version"
         )
     }
 }

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/extensions/ProjectExt.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/extensions/ProjectExt.kt
@@ -5,6 +5,7 @@ import com.android.build.gradle.BasePlugin
 import de.mannodermaus.gradle.plugins.junit5.dsl.AndroidJUnitPlatformExtension
 import de.mannodermaus.gradle.plugins.junit5.internal.config.EXTENSION_NAME
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
@@ -33,5 +34,23 @@ internal fun Project.whenAndroidPluginAdded(block: (BasePlugin) -> Unit) {
         if (!configured.get()) {
             throw IllegalStateException("An Android plugin must be applied in order for android-junit5 to work correctly!")
         }
+    }
+}
+
+internal fun Project.hasDependency(configurationName: String, matching: (Dependency) -> Boolean): Boolean {
+    val configuration = project.configurations.getByName(configurationName)
+
+    return configuration.dependencies.any(matching)
+}
+
+internal fun Project.usesJUnitJupiterIn(configurationName: String): Boolean {
+    return project.hasDependency(configurationName) {
+        it.group == "org.junit.jupiter" && it.name == "junit-jupiter-api"
+    }
+}
+
+internal fun Project.usesComposeIn(configurationName: String): Boolean {
+    return project.hasDependency(configurationName) {
+        it.group?.startsWith("androidx.compose") ?: false
     }
 }

--- a/plugin/android-junit5/src/main/templates/Libraries.kt
+++ b/plugin/android-junit5/src/main/templates/Libraries.kt
@@ -2,6 +2,7 @@ package de.mannodermaus
 
 internal object Libraries {
     const val instrumentationVersion = "@INSTRUMENTATION_VERSION@"
+    const val instrumentationCompose = "@INSTRUMENTATION_GROUP@:@INSTRUMENTATION_COMPOSE@"
     const val instrumentationCore = "@INSTRUMENTATION_GROUP@:@INSTRUMENTATION_CORE@"
     const val instrumentationExtensions = "@INSTRUMENTATION_GROUP@:@INSTRUMENTATION_EXTENSIONS@"
     const val instrumentationRunner = "@INSTRUMENTATION_GROUP@:@INSTRUMENTATION_RUNNER@"

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/GradleTruth.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/GradleTruth.kt
@@ -1,0 +1,68 @@
+package de.mannodermaus.gradle.plugins.junit5.util
+
+import com.google.common.truth.FailureMetadata
+import com.google.common.truth.Subject
+import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertWithMessage
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+
+/* Methods */
+
+fun assertThat(actual: Project): ProjectSubject =
+    Truth.assertAbout(::ProjectSubject).that(actual)
+
+/* Types */
+
+class ProjectSubject(
+    metadata: FailureMetadata,
+    private val actual: Project?,
+) : Subject(metadata, actual) {
+
+    fun configuration(name: String): ConfigurationSubject = check("configuration()")
+        .about(::ConfigurationSubject)
+        .that(actual?.configurations?.getByName(name))
+}
+
+class ConfigurationSubject(
+    metadata: FailureMetadata,
+    private val actual: Configuration?,
+) : Subject(metadata, actual) {
+    private val dependencyNames by lazy {
+        actual?.dependencies
+            ?.map { "${it.group}:${it.name}:${it.version}" }
+            .orEmpty()
+    }
+
+    fun hasDependency(notation: String) {
+        containsDependency(notation, expectExists = true)
+    }
+
+    fun doesNotHaveDependency(notation: String) {
+        containsDependency(notation, expectExists = false)
+    }
+
+    /* Private */
+
+    private fun containsDependency(notation: String, expectExists: Boolean) {
+        // If the expected dependency has a version component,
+        // include it in the check. Otherwise, check for the existence
+        // of _any_ version for the dependency in question
+        val notationIncludesVersion = notation.count { it == ':' } > 1
+        val hasMatch = if (notationIncludesVersion) {
+            notation in dependencyNames
+        } else {
+            dependencyNames.any { it.startsWith("$notation:") }
+        }
+
+        val messagePrefix = if (expectExists) {
+            "Expected to have a dependency on '$notation' in configuration '${actual?.name}', but did not."
+        } else {
+            "Expected not to have a dependency on '$notation' in configuration '${actual?.name}', but did."
+        }
+
+        assertWithMessage(
+            "$messagePrefix\nDependencies in this configuration: $dependencyNames"
+        ).that(hasMatch).isEqualTo(expectExists)
+    }
+}


### PR DESCRIPTION
It needs to detect an androidx.compose artifact in the androidTestImplementation configuration for this to work, but from there it sets itself up automatically, just like the main libraries do when they see junit-jupiter-api