### PR TITLE
Use square brackets for parameterized tests to ensure that their logs show correctly

### DIFF
--- a/instrumentation/runner/src/main/kotlin/de/mannodermaus/junit5/internal/formatters/TestNameFormatter.kt
+++ b/instrumentation/runner/src/main/kotlin/de/mannodermaus/junit5/internal/formatters/TestNameFormatter.kt
@@ -37,6 +37,14 @@ internal object TestNameFormatter {
             }
         }
 
-        return identifier.displayName.replace("()", "")
+        // Process the display name before handing it out,
+        // maintaining compatibility with the expectations of Android's instrumentation:
+        // - Cut off no-parameter brackets '()'
+        // - Replace any other round brackets with square brackets (for parameterized tests)
+        //   to ensure that logs are displayed in the test results window (ref. #350)
+        return identifier.displayName
+            .replace("()", "")
+            .replace('(', '[')
+            .replace(')', ']')
     }
 }

--- a/instrumentation/runner/src/test/kotlin/de/mannodermaus/junit5/internal/formatters/TestNameFormatterTests.kt
+++ b/instrumentation/runner/src/test/kotlin/de/mannodermaus/junit5/internal/formatters/TestNameFormatterTests.kt
@@ -26,7 +26,7 @@ class TestNameFormatterTests {
 
     @Test
     fun `repeated test`() = runTestWith(HasRepeatedTest::class) { identifier ->
-        assertThat(identifier.format(false)).isEqualTo("method(RepetitionInfo)")
+        assertThat(identifier.format(false)).isEqualTo("method[RepetitionInfo]")
         assertThat(identifier.format(true)).isEqualTo("method")
 
         // Inspect individual executions, too
@@ -52,7 +52,7 @@ class TestNameFormatterTests {
 
     @Test
     fun `test template`() = runTestWith(HasTestTemplate::class) { identifier ->
-        assertThat(identifier.format(false)).isEqualTo("method(String)")
+        assertThat(identifier.format(false)).isEqualTo("method[String]")
         assertThat(identifier.format(true)).isEqualTo("method")
 
         // Inspect individual executions, too
@@ -65,7 +65,7 @@ class TestNameFormatterTests {
 
     @Test
     fun `parameterized test`() = runTestWith(HasParameterizedTest::class) { identifier ->
-        assertThat(identifier.format(false)).isEqualTo("method(String)")
+        assertThat(identifier.format(false)).isEqualTo("method[String]")
         assertThat(identifier.format(true)).isEqualTo("method")
 
         // Inspect individual executions, too

--- a/instrumentation/runner/src/test/kotlin/de/mannodermaus/junit5/internal/runners/AndroidJUnitPlatformTestTreeTests.kt
+++ b/instrumentation/runner/src/test/kotlin/de/mannodermaus/junit5/internal/runners/AndroidJUnitPlatformTestTreeTests.kt
@@ -27,7 +27,7 @@ class AndroidJUnitPlatformTestTreeTests {
         }
 
     @CsvSource(
-        "false, method(RepetitionInfo) - repetition %d of 5",
+        "false, method[RepetitionInfo] - repetition %d of 5",
         "true, method[%d]",
     )
     @ParameterizedTest
@@ -62,7 +62,7 @@ class AndroidJUnitPlatformTestTreeTests {
         }
 
     @CsvSource(
-        "false, method(String) - %s",
+        "false, method[String] - %s",
         "true, method[%d]",
     )
     @ParameterizedTest
@@ -83,7 +83,7 @@ class AndroidJUnitPlatformTestTreeTests {
         }
 
     @CsvSource(
-        "false, method(String) - [%d] %s",
+        "false, method[String] - [%d] %s",
         "true, method[%d]",
     )
     @ParameterizedTest


### PR DESCRIPTION
Resolves #350.