### PR TITLE
AGP 8.11 Alpha 1 & accommodations for old versions

### DIFF
--- a/build-logic/src/main/kotlin/Environment.kt
+++ b/build-logic/src/main/kotlin/Environment.kt
@@ -6,9 +6,10 @@ import java.util.Properties
 
 enum class SupportedAgp(
     val version: String,
-    val gradle: String? = null
+    val gradle: String,
+    val compileSdk: Int? = null
 ) {
-    AGP_8_0("8.0.2", gradle = "8.0"),
+    AGP_8_0("8.0.2", gradle = "8.0", compileSdk = 33),
     AGP_8_1("8.1.4", gradle = "8.0"),
     AGP_8_2("8.2.2", gradle = "8.2"),
     AGP_8_3("8.3.2", gradle = "8.4"),

--- a/build-logic/src/main/kotlin/Environment.kt
+++ b/build-logic/src/main/kotlin/Environment.kt
@@ -19,6 +19,7 @@ enum class SupportedAgp(
     AGP_8_8("8.8.2", gradle = "8.10.2"),
     AGP_8_9("8.9.0", gradle = "8.11.1"),
     AGP_8_10("8.10.0-alpha07", gradle = "8.11.1"),
+    AGP_8_11("8.11.0-alpha01", gradle = "8.13")
     ;
 
     companion object {

--- a/build-logic/src/main/kotlin/Tasks.kt
+++ b/build-logic/src/main/kotlin/Tasks.kt
@@ -34,21 +34,28 @@ fun Project.configureTestResources() {
                 "JUNIT5_ANDROID_LIBS_VERSION" to Artifacts.Instrumentation.Core.latestStableVersion,
 
                 // Collect all supported AGP versions into a single string.
-                // This string is delimited with semicolons, and each of the separated values itself is a 3-tuple.
+                // This string is delimited with semicolons, and each of the separated values itself is a 4-tuple.
                 //
                 // Example:
-                // AGP_VERSIONS = 3.5|3.5.3|;3.6|3.6.3|6.4
+                // AGP_VERSIONS = 3.5|3.5.3|;3.6|3.6.3|6.4;3.7|3.7.0|8.0|33
                 //
                 // Can be parsed into this list of values:
                 // |___> Short: "3.5"
                 //       Full: "3.5.3"
-                //       Gradle Requirement: null
+                //       Gradle Requirement: ""
+                //       Compile SDK: null
                 //
                 // |___> Short: "3.6"
                 //       Full: "3.6.3"
                 //       Gradle Requirement: "6.4"
+                //       Compile SDK: null
+                //
+                // |___> Short: "3.7"
+                //       Full: "3.7.0"
+                //       Gradle Requirement: "8.0"
+                //       Compile SDK: 33
                 "AGP_VERSIONS" to SupportedAgp.values().joinToString(separator = ";") { plugin ->
-                    "${plugin.shortVersion}|${plugin.version}|${plugin.gradle ?: ""}"
+                    "${plugin.shortVersion}|${plugin.version}|${plugin.gradle}|${plugin.compileSdk ?: ""}"
                 }
         )
 

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/ConfigurationCacheTests.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/ConfigurationCacheTests.kt
@@ -69,7 +69,7 @@ class ConfigurationCacheTests {
     private fun runGradle(project: File, task: String, expectSuccess: Boolean) =
         GradleRunner.create()
             .withProjectDir(project)
-            .apply { agp.requiresGradle?.let(::withGradleVersion) }
+            .withGradleVersion(agp.requiresGradle)
             .withArguments("--configuration-cache", "--stacktrace", task)
             .withPrunedPluginClasspath(agp)
             .run {

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/FunctionalTests.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/FunctionalTests.kt
@@ -72,7 +72,12 @@ class FunctionalTests {
                 projectCreator.allSpecs.filterSpecs().map { spec ->
                     dynamicTest(spec.name) {
                         // Required for visibility inside IJ's logging console (display names are still bugged in the IDE)
-                        println("AGP: ${agp.version}, Project: ${spec.name}, Forced Gradle: ${agp.requiresGradle ?: "no"}")
+                        println(buildList {
+                            add("AGP: ${agp.version}")
+                            add("Project: ${spec.name}")
+                            add("Gradle: ${agp.requiresGradle}")
+                            agp.requiresCompileSdk?.let { add("SDK: $it") }
+                        }.joinToString(", "))
 
                         // Create a virtual project with the given settings & AGP version.
                         // This call will throw a TestAbortedException if the spec is not eligible for this version,
@@ -147,11 +152,7 @@ class FunctionalTests {
         }
 
         return GradleRunner.create()
-            .apply {
-                if (agpVersion.requiresGradle != null) {
-                    withGradleVersion(agpVersion.requiresGradle)
-                }
-            }
+            .withGradleVersion(agpVersion.requiresGradle)
             .withArguments(arguments)
             .withPrunedPluginClasspath(agpVersion)
     }

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/TestEnvironment.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/TestEnvironment.kt
@@ -51,7 +51,7 @@ class TestEnvironment {
     junit5AndroidLibsVersion = envProps.getProperty(JUNIT5_ANDROID_PROP_NAME)
 
     // Each entry in this string is separated by semicolon.
-    // Within each entry, the pipe ("|") divides it into three properties
+    // Within each entry, the pipe ("|") divides it into four properties
     val agpVersionsString = envProps.getProperty(AGP_VERSIONS_PROP_NAME)
     supportedAgpVersions = agpVersionsString.split(";")
         .map { entry -> entry.split("|") }
@@ -59,7 +59,8 @@ class TestEnvironment {
           TestedAgp(
               shortVersion = values[0],
               version = values[1],
-              requiresGradle = values[2].ifEmpty { null }
+              requiresGradle = values[2],
+              requiresCompileSdk = values[3].toIntOrNull()
           )
         }
   }

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/TestedAgp.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/TestedAgp.kt
@@ -1,5 +1,10 @@
 package de.mannodermaus.gradle.plugins.junit5.util
 
-data class TestedAgp(val shortVersion: String, val version: String, val requiresGradle: String?) {
+data class TestedAgp(
+  val shortVersion: String,
+  val version: String,
+  val requiresGradle: String,
+  val requiresCompileSdk: Int?
+) {
   val fileKey: String = "agp${shortVersion.replace(".", "")}x"
 }

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/projects/FunctionalTestProjectCreator.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/util/projects/FunctionalTestProjectCreator.kt
@@ -3,8 +3,8 @@ package de.mannodermaus.gradle.plugins.junit5.util.projects
 import com.uchuhimo.konf.Config
 import com.uchuhimo.konf.ConfigSpec
 import com.uchuhimo.konf.source.toml
-import de.mannodermaus.gradle.plugins.junit5.util.TestedAgp
 import de.mannodermaus.gradle.plugins.junit5.util.TestEnvironment
+import de.mannodermaus.gradle.plugins.junit5.util.TestedAgp
 import org.gradle.util.GradleVersion
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.opentest4j.TestAbortedException
@@ -19,167 +19,171 @@ private const val PROJECT_CONFIG_FILE_NAME = "config.toml"
 private const val SRC_FOLDER_NAME = "src"
 
 class FunctionalTestProjectCreator(
-  private val outputFolder: File,
-  private val environment: TestEnvironment
+    private val outputFolder: File,
+    private val environment: TestEnvironment
 ) {
 
-  private val projectRootFolder: File
-  val allSpecs: List<Spec>
+    private val projectRootFolder: File
+    val allSpecs: List<Spec>
 
-  init {
-    // Obtain access to the root folder for all test projects
-    val rootUrl = FunctionalTestProjectCreator::class.java.getResource(TEST_PROJECTS_RESOURCE)
-    projectRootFolder = File(rootUrl.toURI())
+    init {
+        // Obtain access to the root folder for all test projects
+        val rootUrl = FunctionalTestProjectCreator::class.java.getResource(TEST_PROJECTS_RESOURCE)
+        projectRootFolder = File(rootUrl.toURI())
 
-    // Collect all eligible test folders
-    allSpecs = projectRootFolder.listFiles()
-      ?.filter { it.isDirectory }
-      ?.mapNotNull { folder -> Spec.tryCreate(folder) }
-      ?: emptyList()
-  }
-
-  fun specNamed(name: String): Spec =
-    allSpecs.firstOrNull { it.name == name }
-      ?: throw IllegalAccessException("No test project named '$name' found in src/test/resources/test-projects")
-
-  @Throws(TestAbortedException::class)
-  fun createProject(spec: Spec, agp: TestedAgp): File {
-    // Validate the spec requirement against the executing AGP version first
-    validateSpec(spec, agp)
-
-    // Construct the project folder, cleaning it if necessary.
-    // If any Gradle or build caches already exist, we keep those around.
-    // That's the reason for not doing "projectFolder.deleteRecursively()"
-    // and nuking everything at once.
-    val projectName = "${spec.name}_${agp.shortVersion}"
-    val projectFolder = File(outputFolder, projectName)
-    if (projectFolder.exists()) {
-      File(projectFolder, SRC_FOLDER_NAME).deleteRecursively()
-      File(projectFolder, OUTPUT_BUILD_GRADLE_NAME).delete()
-      File(projectFolder, OUTPUT_SETTINGS_GRADLE_NAME).delete()
-    }
-    projectFolder.mkdirs()
-
-    // Set up static files
-    File(projectFolder, "local.properties").bufferedWriter().use { file ->
-      file.write("sdk.dir = ${environment.androidSdkFolder.absolutePath}")
-    }
-    File(projectFolder, "gradle.properties").bufferedWriter().use { file ->
-      file.write("android.useAndroidX = true")
+        // Collect all eligible test folders
+        allSpecs = projectRootFolder.listFiles()
+            ?.filter { it.isDirectory }
+            ?.mapNotNull { folder -> Spec.tryCreate(folder) }
+            ?: emptyList()
     }
 
-    // Copy over the source folders
-    val targetSrcFolder = File(projectFolder, "src").also { it.mkdir() }
-    spec.srcFolder.copyRecursively(targetSrcFolder)
+    fun specNamed(name: String): Spec =
+        allSpecs.firstOrNull { it.name == name }
+            ?: throw IllegalAccessException("No test project named '$name' found in src/test/resources/test-projects")
 
-    // Construct the build script from its raw template, using the environment properties as placeholders
-    val replacements = environment.envProps.mapKeys { it.key.toString() }.toMutableMap()
-    replacements["AGP_VERSION"] = agp.version
-    replacements["USE_KOTLIN"] = spec.useKotlin
-    replacements["USE_FLAVORS"] = spec.useFlavors
-    replacements["USE_JACOCO"] = spec.useJacoco
-    replacements["USE_CUSTOM_BUILD_TYPE"] = spec.useCustomBuildType
-    replacements["RETURN_DEFAULT_VALUES"] = spec.returnDefaultValues
-    replacements["INCLUDE_ANDROID_RESOURCES"] = spec.includeAndroidResources
-    replacements["DISABLE_TESTS_FOR_BUILD_TYPES"] = spec.disableTestsForBuildTypes
+    @Throws(TestAbortedException::class)
+    fun createProject(spec: Spec, agp: TestedAgp): File {
+        // Validate the spec requirement against the executing AGP version first
+        validateSpec(spec, agp)
 
-    val processor = BuildScriptTemplateProcessor(
-      folder = projectRootFolder,
-      replacements = replacements,
-      agpVersion = agp.version,
-      gradleVersion = agp.requiresGradle ?: GradleVersion.current().version
-    )
+        // Construct the project folder, cleaning it if necessary.
+        // If any Gradle or build caches already exist, we keep those around.
+        // That's the reason for not doing "projectFolder.deleteRecursively()"
+        // and nuking everything at once.
+        val projectName = "${spec.name}_${agp.shortVersion}"
+        val projectFolder = File(outputFolder, projectName)
+        if (projectFolder.exists()) {
+            File(projectFolder, SRC_FOLDER_NAME).deleteRecursively()
+            File(projectFolder, OUTPUT_BUILD_GRADLE_NAME).delete()
+            File(projectFolder, OUTPUT_SETTINGS_GRADLE_NAME).delete()
+        }
+        projectFolder.mkdirs()
 
-    processor.process(BUILD_GRADLE_TEMPLATE_NAME).also { result ->
-      File(projectFolder, OUTPUT_BUILD_GRADLE_NAME).writeText(result)
-    }
-
-    processor.process(SETTINGS_GRADLE_TEMPLATE_NAME).also { result ->
-      File(projectFolder, OUTPUT_SETTINGS_GRADLE_NAME).writeText(result)
-    }
-
-    return projectFolder
-  }
-
-  private fun validateSpec(spec: Spec, agp: TestedAgp) {
-    if (spec.minAgpVersion != null) {
-      // If the spec dictates a minimum version of the AGP,
-      // disable the test for plugin versions below that minimum requirement
-      assumeTrue(
-        SemanticVersion(agp.version) >= SemanticVersion(spec.minAgpVersion),
-        "This project requires AGP ${spec.minAgpVersion} and was disabled on this version."
-      )
-    }
-  }
-
-  /* Types */
-
-  class Spec private constructor(
-    val name: String,
-    val srcFolder: File,
-    config: Config
-  ) {
-    val task = config[TomlSpec.Settings.task]
-    val minAgpVersion = config[TomlSpec.Settings.minAgpVersion]
-    val useKotlin = config[TomlSpec.Settings.useKotlin]
-    val useJacoco = config[TomlSpec.Settings.useJacoco]
-    val useFlavors = config[TomlSpec.Settings.useFlavors]
-    val useCustomBuildType = config[TomlSpec.Settings.useCustomBuildType]
-    val returnDefaultValues = config[TomlSpec.Settings.returnDefaultValues]
-    val includeAndroidResources = config[TomlSpec.Settings.includeAndroidResources]
-    val expectedTests = config[TomlSpec.expectations]
-
-    val disableTestsForBuildTypes = config[TomlSpec.Settings.disableTestsForBuildTypes]
-      ?.split(",")?.map(String::trim)
-      ?: emptyList()
-
-    companion object {
-      fun tryCreate(folder: File): Spec? {
-        if (folder.isFile) {
-          return null
+        // Set up static files
+        File(projectFolder, "local.properties").bufferedWriter().use { file ->
+            file.write("sdk.dir = ${environment.androidSdkFolder.absolutePath}")
+        }
+        File(projectFolder, "gradle.properties").bufferedWriter().use { file ->
+            file.write("android.useAndroidX = true")
         }
 
-        val srcFolder = File(folder, SRC_FOLDER_NAME)
-        if (!srcFolder.exists()) {
-          return null
+        // Copy over the source folders
+        val targetSrcFolder = File(projectFolder, "src").also { it.mkdir() }
+        spec.srcFolder.copyRecursively(targetSrcFolder)
+
+        // Construct the build script from its raw template, using the environment properties as placeholders
+        val replacements = environment.envProps.mapKeys { it.key.toString() }.toMutableMap()
+        replacements["AGP_VERSION"] = agp.version
+        replacements["USE_KOTLIN"] = spec.useKotlin
+        replacements["USE_FLAVORS"] = spec.useFlavors
+        replacements["USE_JACOCO"] = spec.useJacoco
+        replacements["USE_CUSTOM_BUILD_TYPE"] = spec.useCustomBuildType
+        replacements["RETURN_DEFAULT_VALUES"] = spec.returnDefaultValues
+        replacements["INCLUDE_ANDROID_RESOURCES"] = spec.includeAndroidResources
+        replacements["DISABLE_TESTS_FOR_BUILD_TYPES"] = spec.disableTestsForBuildTypes
+
+        agp.requiresCompileSdk?.let {
+            replacements["OVERRIDE_SDK_VERSION"] = it
         }
 
-        val configFile = File(folder, PROJECT_CONFIG_FILE_NAME)
-        if (!configFile.exists()) {
-          return null
+        val processor = BuildScriptTemplateProcessor(
+            folder = projectRootFolder,
+            replacements = replacements,
+            agpVersion = agp.version,
+            gradleVersion = agp.requiresGradle
+        )
+
+        processor.process(BUILD_GRADLE_TEMPLATE_NAME).also { result ->
+            File(projectFolder, OUTPUT_BUILD_GRADLE_NAME).writeText(result)
         }
 
-        val config = Config { addSpec(TomlSpec) }.from.toml.file(configFile)
-        return Spec(folder.name, srcFolder, config)
-      }
+        processor.process(SETTINGS_GRADLE_TEMPLATE_NAME).also { result ->
+            File(projectFolder, OUTPUT_SETTINGS_GRADLE_NAME).writeText(result)
+        }
+
+        return projectFolder
     }
-  }
 
-  // Structure of the virtual project config file, used only internally
-  private object TomlSpec : ConfigSpec(prefix = "") {
-    val expectations by optional<List<ExpectedTests>>(default = emptyList())
-
-    object Settings : ConfigSpec() {
-      val task by optional<String?>(default = null)
-      val minAgpVersion by optional<String?>(default = null)
-      val useFlavors by optional(default = false)
-      val useKotlin by optional(default = false)
-      val useJacoco by optional(default = false)
-      val useCustomBuildType by optional<String?>(default = null)
-      val returnDefaultValues by optional(default = false)
-      val includeAndroidResources by optional(default = false)
-      val disableTestsForBuildTypes by optional<String?>(default = null)
+    private fun validateSpec(spec: Spec, agp: TestedAgp) {
+        if (spec.minAgpVersion != null) {
+            // If the spec dictates a minimum version of the AGP,
+            // disable the test for plugin versions below that minimum requirement
+            assumeTrue(
+                SemanticVersion(agp.version) >= SemanticVersion(spec.minAgpVersion),
+                "This project requires AGP ${spec.minAgpVersion} and was disabled on this version."
+            )
+        }
     }
-  }
 
-  /**
-   * Data holder for one set of expected tests within the virtual project
-   */
-  data class ExpectedTests(
-    val buildType: String,
-    val productFlavor: String?,
-    private val tests: String
-  ) {
-    val testsList = tests.split(",").map(String::trim)
-  }
+    /* Types */
+
+    class Spec private constructor(
+        val name: String,
+        val srcFolder: File,
+        config: Config
+    ) {
+        val task = config[TomlSpec.Settings.task]
+        val minAgpVersion = config[TomlSpec.Settings.minAgpVersion]
+        val useKotlin = config[TomlSpec.Settings.useKotlin]
+        val useJacoco = config[TomlSpec.Settings.useJacoco]
+        val useFlavors = config[TomlSpec.Settings.useFlavors]
+        val useCustomBuildType = config[TomlSpec.Settings.useCustomBuildType]
+        val returnDefaultValues = config[TomlSpec.Settings.returnDefaultValues]
+        val includeAndroidResources = config[TomlSpec.Settings.includeAndroidResources]
+        val expectedTests = config[TomlSpec.expectations]
+
+        val disableTestsForBuildTypes = config[TomlSpec.Settings.disableTestsForBuildTypes]
+            ?.split(",")?.map(String::trim)
+            ?: emptyList()
+
+        companion object {
+            fun tryCreate(folder: File): Spec? {
+                if (folder.isFile) {
+                    return null
+                }
+
+                val srcFolder = File(folder, SRC_FOLDER_NAME)
+                if (!srcFolder.exists()) {
+                    return null
+                }
+
+                val configFile = File(folder, PROJECT_CONFIG_FILE_NAME)
+                if (!configFile.exists()) {
+                    return null
+                }
+
+                val config = Config { addSpec(TomlSpec) }.from.toml.file(configFile)
+                return Spec(folder.name, srcFolder, config)
+            }
+        }
+    }
+
+    // Structure of the virtual project config file, used only internally
+    private object TomlSpec : ConfigSpec(prefix = "") {
+        val expectations by optional<List<ExpectedTests>>(default = emptyList())
+
+        object Settings : ConfigSpec() {
+            val task by optional<String?>(default = null)
+            val minAgpVersion by optional<String?>(default = null)
+            val useFlavors by optional(default = false)
+            val useKotlin by optional(default = false)
+            val useJacoco by optional(default = false)
+            val useCustomBuildType by optional<String?>(default = null)
+            val returnDefaultValues by optional(default = false)
+            val includeAndroidResources by optional(default = false)
+            val disableTestsForBuildTypes by optional<String?>(default = null)
+        }
+    }
+
+    /**
+     * Data holder for one set of expected tests within the virtual project
+     */
+    data class ExpectedTests(
+        val buildType: String,
+        val productFlavor: String?,
+        private val tests: String
+    ) {
+        val testsList = tests.split(",").map(String::trim)
+    }
 }

--- a/plugin/android-junit5/src/test/resources/test-projects/build.gradle.kts.template
+++ b/plugin/android-junit5/src/test/resources/test-projects/build.gradle.kts.template
@@ -58,9 +58,15 @@ repositories {
 }
 
 android {
-  val compileSdk: String = "{{ COMPILE_SDK_VERSION }}"
   val minSdk: Int = {{ MIN_SDK_VERSION }}
-  val targetSdk: Int = {{ TARGET_SDK_VERSION }}
+
+  {% if OVERRIDE_SDK_VERSION %}
+    val compileSdk: String = "android-{{ OVERRIDE_SDK_VERSION }}"
+    val targetSdk: Int = {{ OVERRIDE_SDK_VERSION }}
+  {% else %}
+    val compileSdk: String = "{{ COMPILE_SDK_VERSION }}"
+    val targetSdk: Int = {{ TARGET_SDK_VERSION }}
+  {% endif %}
 
   compileSdkVersion("${compileSdk}")
 


### PR DESCRIPTION
AGP 8.0 does not support any compileSdk above 33, so change the test infrastructure to enforce that sdk version. Others still use 35 as normal.