### PR TITLE
Update to JUnit 5.13 RC1 & Kotlin 2.x

### DIFF
--- a/README.md.template
+++ b/README.md.template
@@ -280,7 +280,8 @@ before filing an issue with the latest one.
 
 |Your AGP Version|Suggested JUnit5 Plugin Version|
 |---|---|
-|`>= 8.0.0`|`${pluginVersion}`|
+|`>= 8.2.0`|`${pluginVersion}`|
+|`8.0.0` - `8.1.4`|`1.12.2.0`|
 |`7.0.0` - `7.4.2`|`1.10.0.0`|
 |`4.0.0` - `4.2.2`|`1.8.2.1`|
 |`3.5.0` - `3.6.4`|`1.7.1.1`|

--- a/build-logic/src/main/kotlin/Dependencies.kt
+++ b/build-logic/src/main/kotlin/Dependencies.kt
@@ -2,10 +2,10 @@
 
 object libs {
     object versions {
-        const val kotlin = "1.9.25" // Can only once minimum supported AGP is >= 8.2
-        const val junitJupiter = "5.12.2"
-        const val junitVintage = "5.12.2"
-        const val junitPlatform = "1.12.2"
+        const val kotlin = "2.1.21"
+        const val junitJupiter = "5.13.0-RC1"
+        const val junitVintage = "5.13.0-RC1"
+        const val junitPlatform = "1.13.0-RC1"
 
         const val composeBom = "2025.03.00"
         const val androidXMultidex = "2.0.1"
@@ -17,7 +17,7 @@ object libs {
 
         const val activityCompose = "1.10.1"
         const val apiGuardian = "1.1.2"
-        const val coroutines = "1.8.1" // Can only update once minimum supported AGP is >= 8.2
+        const val coroutines = "1.10.2"
         const val dokka = "2.0.0"
         const val espresso = "3.6.1"
         const val javaSemver = "0.10.2"

--- a/build-logic/src/main/kotlin/Dependencies.kt
+++ b/build-logic/src/main/kotlin/Dependencies.kt
@@ -22,6 +22,8 @@ object libs {
         const val javaSemver = "0.10.2"
         const val junit4 = "4.13.2"
         const val konfToml = "1.1.2"
+        const val kotlinxBinaryCompatibilityValidator = "0.17.0"
+        const val nexusPublish = "2.0.0"
         const val korte = "2.4.12"
         const val mockitoCore = "5.16.0"
         const val mockitoKotlin = "5.4.0"

--- a/build-logic/src/main/kotlin/Dependencies.kt
+++ b/build-logic/src/main/kotlin/Dependencies.kt
@@ -13,7 +13,6 @@ object libs {
         const val androidXTestCore = "1.6.1"
         const val androidXTestMonitor = "1.7.2"
         const val androidXTestRunner = "1.6.2"
-        const val composeCompiler = "1.5.15"
 
         const val activityCompose = "1.10.1"
         const val apiGuardian = "1.1.2"
@@ -33,6 +32,7 @@ object libs {
 
     object plugins {
         fun android(version: SupportedAgp) = "com.android.tools.build:gradle:${version.version}"
+        const val composeCompiler = "org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin:${versions.kotlin}"
         const val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${libs.versions.kotlin}"
         const val shadow = "com.github.johnrengelman:shadow:${libs.versions.shadow}"
         const val dokka = "org.jetbrains.dokka:dokka-gradle-plugin:${libs.versions.dokka}"

--- a/build-logic/src/main/kotlin/Environment.kt
+++ b/build-logic/src/main/kotlin/Environment.kt
@@ -9,8 +9,6 @@ enum class SupportedAgp(
     val gradle: String,
     val compileSdk: Int? = null
 ) {
-    AGP_8_0("8.0.2", gradle = "8.0", compileSdk = 33),
-    AGP_8_1("8.1.4", gradle = "8.0"),
     AGP_8_2("8.2.2", gradle = "8.2"),
     AGP_8_3("8.3.2", gradle = "8.4"),
     AGP_8_4("8.4.2", gradle = "8.6"),

--- a/build-logic/src/main/kotlin/Tasks.kt
+++ b/build-logic/src/main/kotlin/Tasks.kt
@@ -17,7 +17,7 @@ import java.io.File
 import java.time.ZonedDateTime
 import java.util.*
 
-private const val minimumGradleVersion = "8.0"
+private const val minimumGradleVersion = "8.2"
 
 @Suppress("DEPRECATION")
 fun Project.configureTestResources() {

--- a/instrumentation/CHANGELOG.md
+++ b/instrumentation/CHANGELOG.md
@@ -4,6 +4,7 @@ Change Log
 ## Unreleased
 
 - Compile with SDK 35
+- Update to Kotlin 2.x
 
 ## 1.7.0 (2025-03-01)
 

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  id("io.github.gradle-nexus.publish-plugin").version("2.0.0")
-  id("org.jetbrains.kotlinx.binary-compatibility-validator").version("0.14.0")
+  id("io.github.gradle-nexus.publish-plugin").version(libs.versions.nexusPublish)
+  id("org.jetbrains.kotlinx.binary-compatibility-validator").version(libs.versions.kotlinxBinaryCompatibilityValidator)
 }
 
 buildscript {

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -7,6 +7,7 @@ buildscript {
   dependencies {
     classpath(libs.plugins.kotlin)
     classpath(libs.plugins.dokka)
+    classpath(libs.plugins.composeCompiler)
     classpath(libs.plugins.android(SupportedAgp.newestStable))
   }
 }

--- a/instrumentation/compose/build.gradle.kts
+++ b/instrumentation/compose/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   kotlin("android")
   id("explicit-api-mode")
   id("de.mannodermaus.android-junit5").version(Artifacts.Plugin.latestStableVersion)
+  id("org.jetbrains.kotlin.plugin.compose")
 }
 
 val javaVersion = JavaVersion.VERSION_11
@@ -34,10 +35,6 @@ android {
 
   kotlinOptions {
     jvmTarget = javaVersion.toString()
-  }
-
-  composeOptions {
-    kotlinCompilerExtensionVersion = libs.versions.composeCompiler
   }
 
   testOptions {

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2,6 +2,9 @@ Change Log
 ==========
 
 ## Unreleased
+- JUnit 5.13.0
+- Update to Kotlin 2.x
+- Raise minimum supported versions for AGP and Gradle to 8.2.x and 8.2, respectively
 
 ## 1.12.2.0 (2025-05-18)
 - JUnit 5.12.2

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/config/Constants.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/config/Constants.kt
@@ -2,8 +2,8 @@
 
 package de.mannodermaus.gradle.plugins.junit5.internal.config
 
-internal const val MIN_REQUIRED_GRADLE_VERSION = "8.0" // When updating this, check buildSrc/Tasks.kt and update it there, too
-internal const val MIN_REQUIRED_AGP_VERSION = "8.0.0"
+internal const val MIN_REQUIRED_GRADLE_VERSION = "8.2" // When updating this, check buildSrc/Tasks.kt and update it there, too
+internal const val MIN_REQUIRED_AGP_VERSION = "8.2.0"
 
 internal const val EXTENSION_NAME = "junitPlatform"
 

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/config/PluginConfig.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/config/PluginConfig.kt
@@ -50,7 +50,7 @@ private constructor(
     val hasJacocoPlugin get() = project.plugins.hasPlugin("jacoco")
     private val hasKotlinPlugin get() = project.plugins.findPlugin("kotlin-android") != null
 
-    fun finalizeDsl(block: (CommonExtension<*, *, *, *>) -> Unit) {
+    fun finalizeDsl(block: (CommonExtension<*, *, *, *, *>) -> Unit) {
         componentsExtension.finalizeDsl(block)
     }
 

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/configureJUnit5.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/configureJUnit5.kt
@@ -58,7 +58,7 @@ internal fun configureJUnit5(
 
 /* Private */
 
-private typealias AndroidExtension = CommonExtension<*, *, *, *>
+private typealias AndroidExtension = CommonExtension<*, *, *, *, *>
 
 private fun AndroidJUnitPlatformExtension.prepareBuildTypeDsl(android: AndroidExtension) {
     // This will add filters for build types (e.g. "debug" or "release")

--- a/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/VersionCheckerTests.kt
+++ b/plugin/android-junit5/src/test/kotlin/de/mannodermaus/gradle/plugins/junit5/VersionCheckerTests.kt
@@ -20,14 +20,18 @@ class VersionCheckerTests {
             "7.0.0-rc01, false",
             "7.0.0, false",
             "8.0.0-beta01, false",
-            "8.0.0, true",
-            "8.0.1, true",
-            "8.0.1-alpha01, true",
-            "8.1.0, true",
-            "8.1.0-beta01, true",
+            "8.0.0, false",
+            "8.0.1, false",
+            "8.0.1-alpha01, false",
+            "8.1.0, false",
+            "8.1.0-beta01, false",
             "8.2.0, true",
             "8.3.0-rc01, true",
             "8.4.0-alpha05, true",
+            "8.10.1-alpha01, true",
+            "8.10.0, true",
+            "8.11.0-beta01, true",
+            "8.11.0, true",
     )
     @ParameterizedTest
     fun `check AGP compatibility`(version: String, compatible: Boolean) {

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    id("io.github.gradle-nexus.publish-plugin").version("2.0.0")
-    id("org.jetbrains.kotlinx.binary-compatibility-validator").version("0.14.0")
+    id("io.github.gradle-nexus.publish-plugin").version(libs.versions.nexusPublish)
+    id("org.jetbrains.kotlinx.binary-compatibility-validator").version(libs.versions.kotlinxBinaryCompatibilityValidator)
 }
 
 buildscript {


### PR DESCRIPTION
The update to Kotlin 2.x requires dropping support for AGP 8.0 and 8.1, but it's been long enough IMO.