### PR TITLE
Update to JUnit 5.13 and refactor minimum version detection scheme

### DIFF
--- a/build-logic/src/main/kotlin/Dependencies.kt
+++ b/build-logic/src/main/kotlin/Dependencies.kt
@@ -19,7 +19,6 @@ object libs {
         const val coroutines = "1.10.2"
         const val dokka = "2.0.0"
         const val espresso = "3.6.1"
-        const val javaSemver = "0.10.2"
         const val junit4 = "4.13.2"
         const val konfToml = "1.1.2"
         const val kotlinxBinaryCompatibilityValidator = "0.17.0"
@@ -51,7 +50,6 @@ object libs {
 
     const val kotlinStdLib = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
     const val kotlinCoroutinesCore = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutines}"
-    const val javaSemver = "com.github.zafarkhaja:java-semver:${versions.javaSemver}"
 
     const val junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${versions.junitJupiter}"
     const val junitJupiterParams = "org.junit.jupiter:junit-jupiter-params:${versions.junitJupiter}"

--- a/build-logic/src/main/kotlin/Dependencies.kt
+++ b/build-logic/src/main/kotlin/Dependencies.kt
@@ -3,9 +3,9 @@
 object libs {
     object versions {
         const val kotlin = "2.1.21"
-        const val junitJupiter = "5.13.0-RC1"
-        const val junitVintage = "5.13.0-RC1"
-        const val junitPlatform = "1.13.0-RC1"
+        const val junitJupiter = "5.13.0"
+        const val junitVintage = "5.13.0"
+        const val junitPlatform = "1.13.0"
 
         const val composeBom = "2025.03.00"
         const val androidXMultidex = "2.0.1"

--- a/build-logic/src/main/kotlin/Environment.kt
+++ b/build-logic/src/main/kotlin/Environment.kt
@@ -17,9 +17,9 @@ enum class SupportedAgp(
     AGP_8_7("8.7.3", gradle = "8.9"),
     AGP_8_8("8.8.2", gradle = "8.10.2"),
     AGP_8_9("8.9.3", gradle = "8.11.1"),
-    AGP_8_10("8.10.0", gradle = "8.11.1"),
+    AGP_8_10("8.10.1", gradle = "8.11.1"),
     AGP_8_11("8.11.0-alpha10", gradle = "8.13"),
-    AGP_8_12("8.12.0-alpha01", gradle = "8.13")
+    AGP_8_12("8.12.0-alpha03", gradle = "8.13")
     ;
 
     companion object {

--- a/plugin/android-junit5/build.gradle.kts
+++ b/plugin/android-junit5/build.gradle.kts
@@ -99,7 +99,6 @@ dependencies {
 
     implementation(gradleApi())
     implementation(libs.kotlinStdLib)
-    implementation(libs.javaSemver)
     implementation(libs.junitPlatformCommons)
 
     testImplementation(gradleTestKit())

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/config/Constants.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/config/Constants.kt
@@ -2,8 +2,12 @@
 
 package de.mannodermaus.gradle.plugins.junit5.internal.config
 
-internal const val MIN_REQUIRED_GRADLE_VERSION = "8.2" // When updating this, check buildSrc/Tasks.kt and update it there, too
-internal const val MIN_REQUIRED_AGP_VERSION = "8.2.0"
+import com.android.build.api.AndroidPluginVersion
+import org.gradle.util.GradleVersion
+
+// When updating this, check buildSrc/Tasks.kt and update it there, too
+internal val MIN_REQUIRED_GRADLE_VERSION = GradleVersion.version("8.2")
+internal val MIN_REQUIRED_AGP_VERSION = AndroidPluginVersion(8, 2)
 
 internal const val EXTENSION_NAME = "junitPlatform"
 

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/config/PluginConfig.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/config/PluginConfig.kt
@@ -50,6 +50,8 @@ private constructor(
     val hasJacocoPlugin get() = project.plugins.hasPlugin("jacoco")
     private val hasKotlinPlugin get() = project.plugins.findPlugin("kotlin-android") != null
 
+    val currentAgpVersion get() = componentsExtension.pluginVersion
+
     fun finalizeDsl(block: (CommonExtension<*, *, *, *, *>) -> Unit) {
         componentsExtension.finalizeDsl(block)
     }

--- a/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/utils/Functions.kt
+++ b/plugin/android-junit5/src/main/kotlin/de/mannodermaus/gradle/plugins/junit5/internal/utils/Functions.kt
@@ -1,6 +1,6 @@
 package de.mannodermaus.gradle.plugins.junit5.internal.utils
 
-import com.github.zafarkhaja.semver.Version
+import com.android.build.api.AndroidPluginVersion
 import org.gradle.api.GradleException
 import org.gradle.util.GradleVersion
 
@@ -9,16 +9,14 @@ internal fun excludedPackagingOptions() = listOf(
         "/META-INF/LICENSE-notice.md"
 )
 
-internal fun requireGradle(version: String, message: () -> String) {
-    require(GradleVersion.current() >= GradleVersion.version(version)) {
+internal fun requireGradle(actual: GradleVersion, required: GradleVersion, message: () -> String) {
+    require(actual >= required) {
         throw GradleException(message())
     }
 }
 
-internal fun requireVersion(actual: String, required: String, message: () -> String) {
-    val actualVersion = Version.parse(actual)
-    val requiredVersion = Version.parse(required)
-    require(actualVersion.isHigherThanOrEquivalentTo(requiredVersion)) {
+internal fun requireAgp(actual: AndroidPluginVersion, required: AndroidPluginVersion, message: () -> String) {
+    require(actual >= required) {
         throw GradleException(message())
     }
 }


### PR DESCRIPTION
Use `GradleVersion` and `AndroidPluginVersion` to express the minimum required versions for Gradle and AGP, removing the need for a third-party library.