### PR TITLE
Use correct artifactIds in GMM, too

### DIFF
--- a/build-logic/src/main/kotlin/Environment.kt
+++ b/build-logic/src/main/kotlin/Environment.kt
@@ -88,13 +88,14 @@ object Artifacts {
     const val LICENSE = "Apache-2.0"
 
     /**
-     * Retrieve the artifact configuration based on a Gradle project reference.
-     * Return null if none can be found
+     * Retrieve the artifact configuration based on a string name, or null if none can be found
      */
-    fun from(project: Project) =
-        when (project.name) {
+    fun from(name: String): Deployed? =
+        when (name) {
             "core" -> Instrumentation.Core
+            "extensions" -> Instrumentation.Extensions
             "runner" -> Instrumentation.Runner
+            "compose" -> Instrumentation.Compose
             "android-junit5" -> Plugin
             else -> null
         }


### PR DESCRIPTION
There was already a task to rewrite the POM files associated with each instrumentation library (e.g. replacing `core` with `android-test-core` in the XML), but I overlooked that Gradle has started generating another metadata file that needed replacing: the _Gradle Module Metadata_. This is what is actually being preferred when Gradle resolves variants into dependencies, causing issues like #402 and #403 due to the references being wrong in there, too. This PR fixes that. Unfortunately, the GMM API is internal and most of it inaccessible, so create a "modifier" class to update the references accordingly.